### PR TITLE
Postgrest client: stop using a list as a default arg

### DIFF
--- a/services/utils/postgrest.py
+++ b/services/utils/postgrest.py
@@ -83,7 +83,7 @@ class Postgrest(object):
             resource=resource, method="delete", headers=headers, params=params
         )
 
-    def select(self, resource, params={}, pagination=True, headers=None):
+    def select(self, resource, params=None, pagination=True, headers=None):
         """Fetch selected records from PostgREST. See documentation for horizontal
         and vertical filtering at http://postgrest.org/.
 
@@ -98,6 +98,7 @@ class Postgrest(object):
         Returns:
             List: A list of dicts of data returned from the host
         """
+        params = {} if not params else params
         limit = params.get("limit", math.inf)
         params.setdefault("offset", 0)
         records = []


### PR DESCRIPTION
Avoiding future unexpected behavior by nixing the use of `params=[]` in the `Postgrest.select()` method. This list caused the param list to persist when called multiple times—not the kind of behavior you want in your API client.