### PR TITLE
Use `order_by` param when querying PostgREST

### DIFF
--- a/services/records_to_agol.py
+++ b/services/records_to_agol.py
@@ -54,6 +54,7 @@ def main():
             "container_id": f"eq.{container}",
             "updated_at": f"gte.{filter_iso_date_str}",
         },
+        order_by="updated_at"
     )
 
     logger.debug(f"{len(data)} to process.")

--- a/services/records_to_postgrest.py
+++ b/services/records_to_postgrest.py
@@ -75,6 +75,7 @@ def main():
     logger.info("Downloading records from Knack...")
 
     kwargs = container_kwargs(container, app_config)
+
     records = knackpy.api.get(
         app_id=APP_ID, api_key=API_KEY, filters=filters, **kwargs,
     )
@@ -89,7 +90,7 @@ def main():
     client = utils.postgrest.Postgrest(PGREST_ENDPOINT, token=PGREST_JWT)
 
     if not args.date:
-        # if no date is provided, we're do a full a replace of the data
+        # if no date is provided, we do a full a replace of the data
         client.delete(
             "knack",
             params={"container_id": f"eq.{container}", "app_id": f"eq.{APP_ID}"},

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -7,6 +7,7 @@ import knackpy
 from config.knack import CONFIG
 import utils
 
+
 def handle_floating_timestamps(records, floating_timestamp_fields):
     """ Socrata's fixed timestamp dataType does not allow tz info :(
         (Alternatively, one could setup a transform in Socrata to convert the datatype
@@ -26,7 +27,10 @@ def format_keys(records):
     """ This script assumes that the source knack records' field labels map exactly
     to the socrata API column names, given that they are converted to lower case and
     spaces are replaced with underscores."""
-    return [{key.lower().replace(" ", "_"): val for key, val in record.items()} for record in records]
+    return [
+        {key.lower().replace(" ", "_"): val for key, val in record.items()}
+        for record in records
+    ]
 
 
 def bools_to_strings(records):
@@ -97,6 +101,7 @@ def main():
             "container_id": f"eq.{container}",
             "updated_at": f"gte.{filter_iso_date_str}",
         },
+        order_by="updated_at",
     )
 
     logger.info(f"{len(data)} records to process")

--- a/services/utils/postgrest.py
+++ b/services/utils/postgrest.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 import json
 import math
-import warnings
 
 import requests
 

--- a/services/utils/postgrest.py
+++ b/services/utils/postgrest.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 import json
 import math
+import warnings
 
 import requests
 
@@ -8,7 +9,9 @@ import requests
 def get_metadata(client, app_id):
     """A helper func which fetches an app's metadata based on the provided app_id str"""
     results = client.select(
-        "knack_metadata", params={"app_id": f"eq.{app_id}", "limit": 1}
+        "knack_metadata",
+        params={"app_id": f"eq.{app_id}", "limit": 1},
+        pagination=False,
     )
     if results:
         return results[0]["metadata"]
@@ -83,17 +86,26 @@ class Postgrest(object):
             resource=resource, method="delete", headers=headers, params=params
         )
 
-    def select(self, resource, params=None, pagination=True, headers=None):
+    def select(
+        self, resource, params=None, pagination=True, headers=None, order_by=None
+    ):
         """Fetch selected records from PostgREST. See documentation for horizontal
         and vertical filtering at http://postgrest.org/.
 
         Args:
-            params (dict): PostgREST-compliant request parameters.
-
+            resource (str): Required. The postgrest's endpoint's table or view name to
+                query.
+            headers (dict): Custom PostgREST headers which will be passed to the
+                request. Defaults to None.
+            order_by (str): Field name to use a sort field when querying records. This
+                must be provided when pagniation=True to ensure that the DB returns
+                consistent results across all pages/offsets.
             pagination (bool): If the client should make repeated requests until etiher:
-            -  the limit param (if present) is met
-            -  if no limit param is included, until no more records are returned from
-            the API.
+                -  the limit param (if present) is met
+                -  if no limit param is included, until no more records are returned from
+                    the API.
+                Defaults to True.
+            params (dict): PostgREST-compliant request parameters. Defaults to None.
 
         Returns:
             List: A list of dicts of data returned from the host
@@ -101,6 +113,13 @@ class Postgrest(object):
         params = {} if not params else params
         limit = params.get("limit", math.inf)
         params.setdefault("offset", 0)
+        params["order"] = order_by
+
+        if pagination and not order_by:
+            raise ValueError(
+                "It's not reliable to paginate requests without specifying an 'order_by' field"
+            )
+
         records = []
         headers = self._get_request_headers(headers)
 
@@ -109,6 +128,7 @@ class Postgrest(object):
                 resource=resource, method="get", headers=headers, params=params
             )
             records += data
+
             if not data or len(records) >= limit or not pagination:
                 # Postgrest has a max-rows configuration setting which limits the total
                 # number of rows that can be returned from a request. when the the


### PR DESCRIPTION
> When using LIMIT, it is important to use an ORDER BY clause that constrains the result rows into a unique order. Otherwise you will get an unpredictable subset of the query's rows. You may be asking for the tenth through twentieth rows, but tenth through twentieth in what ordering? The ordering is unknown, unless you specified ORDER BY.