### PR TITLE
5671 - add config for work orders signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+*.env
 
 # Spyder project settings
 .spyderproject

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -71,6 +71,13 @@ CONFIG = {
             "location_field_id": "field_182",
             "layer_id": 0,
             "item_type": "layer",
+        },
+        "view_1829": {
+            "description": "Work Orders Signals",
+            "scene": "scene_683",
+            "modified_date_field": "field_1074",
+            "socrata_resource_id": "hst3-hxcz",
+            "location_field_id": "field_182",
         }
     },
     "signs-markings": {


### PR DESCRIPTION
Issue: https://github.com/cityofaustin/atd-data-tech/issues/5671

Adds the knack configuration for the Work Orders Signals in the Data Tracker.

Here is the corresponding airflow PR: https://github.com/cityofaustin/atd-airflow/pull/48
Corresponding atd-data-deploy PR: https://github.com/cityofaustin/atd-data-deploy/pull/83