### PR TITLE
4341 migrate flashing beacons

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -78,6 +78,16 @@ CONFIG = {
             "modified_date_field": "field_1074",
             "socrata_resource_id": "hst3-hxcz",
             "location_field_id": "field_182",
+        },
+        "view_1454": {
+            "description": "Flashing Beacons",
+            "scene": "scene_519",
+            "modified_date_field": "field_1701",
+            "socrata_resource_id": "wczq-5cer",
+            "location_field_id": "field_211",
+            "service_id": "6c4392540b684d598c72e52206d774be",
+            "layer_id": 0,
+            "item_type": "layer",
         }
     },
     "signs-markings": {

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -79,12 +79,12 @@ CONFIG = {
             "socrata_resource_id": "hst3-hxcz",
             "location_field_id": "field_182",
         },
-        "view_1454": {
+        "view_1563": {
             "description": "Flashing Beacons",
-            "scene": "scene_519",
+            "scene": "scene_568",
             "modified_date_field": "field_1701",
             "socrata_resource_id": "wczq-5cer",
-            "location_field_id": "field_211",
+            "location_field_id": "field_182",
             "service_id": "6c4392540b684d598c72e52206d774be",
             "layer_id": 0,
             "item_type": "layer",

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -50,7 +50,7 @@ def find_field_def(field_defs, field_id):
 
 
 def patch_formatters(field_defs, location_field_id, metadata_socrata):
-    """Replace knackpy's default address fomatter with a custom socrata formatter for
+    """Replace knackpy's default address formatter with a custom socrata formatter for
     either `point` or `location` field types. `location` types are a legacy field
     type, so we have to munge the socrata metadata to determine which type(s) our
     dataset uses."""


### PR DESCRIPTION
Issue: https://github.com/cityofaustin/atd-data-tech/issues/4341

Adds the flashing beacons config. 

Here is the corresponding airflow PR: https://github.com/cityofaustin/atd-airflow/pull/49
Corresponding atd-data-deploy PR: https://github.com/cityofaustin/atd-data-deploy/pull/84

socrata: https://data.austintexas.gov/Transportation-and-Mobility/Flashing-Beacons/wczq-5cer
agol: https://austin.maps.arcgis.com/home/item.html?id=6c4392540b684d598c72e52206d774be#overview