### PR TITLE
4961 - add config for knack detectors

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -88,6 +88,16 @@ CONFIG = {
             "service_id": "6c4392540b684d598c72e52206d774be",
             "layer_id": 0,
             "item_type": "layer",
+        },
+        "view_1333": {
+            "description": "Detectors",
+            "scene": "scene_468",
+            "modified_date_field": "field_1533",
+            "socrata_resource_id": "qpuw-8eeb",
+            "location_field_id": "field_182",
+            "service_id": "47d17ff3ce664849a16b9974979cd12e",
+            "layer_id": 0,
+            "item_type": "layer",
         }
     },
     "signs-markings": {


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/4961

Add config for knack detectors aka traffic detectors on socrata

Here is the corresponding airflow PR: cityofaustin/atd-airflow#50
Corresponding atd-data-deploy PR: cityofaustin/atd-data-deploy#85

**socrata:** https://data.austintexas.gov/Transportation-and-Mobility/Traffic-Detectors/qpuw-8eeb
**agol:** https://austin.maps.arcgis.com/home/item.html?id=47d17ff3ce664849a16b9974979cd12e
**knack:** https://atd.knack.com/amd#signal-queries/signal-detectors-api/
