### PR TITLE
5814 - migrate travel sensors to atd-knack-services

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ If you have a conflicting field in your Knack data named "ID", you should as gen
 
 With the exception of the ID field, all Knack field names will be translated to Socrata-compliant field names by replacing spaces with underscores and making all characters lowercase.
 
+Knack container field names missing from the Socrata dataset's fields will be removed from the payload before publishing.
+
 ```shell
 $ python records_to_socrata.py \
     -a data-tracker \

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -98,6 +98,16 @@ CONFIG = {
             "service_id": "47d17ff3ce664849a16b9974979cd12e",
             "layer_id": 0,
             "item_type": "layer",
+        },
+        "view_540": {
+            "description": "Travel Sensors",
+            "scene": "scene_188",
+            "modified_date_field": "field_710",
+            "socrata_resource_id": "6yd9-yz29",
+            "location_field_id": "field_182",
+            "service_id": "9776d3e894a74521a7f63443f7becc7c",
+            "layer_id": 0,
+            "item_type": "layer"
         }
     },
     "signs-markings": {

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -41,6 +41,23 @@ def bools_to_strings(records):
     return records
 
 
+def ignore_unknown_fields(record_fieldNames, formatted_records, client_metadata):
+    columnNames = []
+    for c in client_metadata["columns"]:
+        columnNames.append(c["fieldName"])
+    fields = []
+    for f in record_fieldNames:
+        if f.lower() not in columnNames:
+            fields.append(f)
+            for r in formatted_records:
+                print(f"deleting {f.lower()}")
+                r.pop(f.lower(), None)
+    # what if we find which fields in the formatted records aren't in the client metadata
+    # if f in field is not in
+
+    pass
+
+
 def find_field_def(field_defs, field_id):
     matched = [f for f in field_defs if f.key == field_id]
     try:
@@ -130,6 +147,9 @@ def main():
     payload = [record.format() for record in records]
     payload = format_keys(payload)
     bools_to_strings(payload)
+    # take out the keys we have in socrata?
+    socrata_metadata = client_socrata.get_metadata(resource_id)
+    ignore_unknown_fields(records[0].names(), payload, socrata_metadata)
     floating_timestamp_fields = utils.socrata.get_floating_timestamp_fields(
         resource_id, metadata_socrata
     )

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -50,7 +50,7 @@ def remove_unknown_fields(record_fieldNames, payload, client_metadata):
     """
     column_names = [c["fieldName"] for c in client_metadata["columns"]]
     unknown_fields = [fieldName.lower() for fieldName in record_fieldNames if fieldName.lower() not in column_names]
-    if len(unknown_fields) > 0:
+    if unknown_fields:
         logger.info(f"Record field names not in Socrata: {unknown_fields}")
         for record in payload:
             for unknown_field in unknown_fields:

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -51,7 +51,7 @@ def remove_unknown_fields(record_fieldNames, payload, client_metadata):
     """
     columnNames = [c["fieldName"] for c in client_metadata["columns"]]
     unknown_fields = [fieldName.lower() for fieldName in record_fieldNames if fieldName.lower() not in columnNames]
-    print(f"Record field names not in Socrata: {unknown_fields}")
+    logger.info(f"Record field names not in Socrata: {unknown_fields}")
     for record in payload:
         for unknown_field in unknown_fields:
             record.pop(unknown_field, None)

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -49,13 +49,13 @@ def remove_unknown_fields(record_fieldNames, payload, client_metadata):
     :param payload: records payload to send to Socrata
     :param client_metadata: Socrata metadata for app
     """
-    columnNames = [c["fieldName"] for c in client_metadata["columns"]]
-    unknown_fields = [fieldName.lower() for fieldName in record_fieldNames if fieldName.lower() not in columnNames]
-    logger.info(f"Record field names not in Socrata: {unknown_fields}")
-    for record in payload:
-        for unknown_field in unknown_fields:
-            record.pop(unknown_field, None)
-    return payload
+    column_names = [c["fieldName"] for c in client_metadata["columns"]]
+    unknown_fields = [fieldName.lower() for fieldName in record_fieldNames if fieldName.lower() not in column_names]
+    if len(unknown_fields) > 0:
+        logger.info(f"Record field names not in Socrata: {unknown_fields}")
+        for record in payload:
+            for unknown_field in unknown_fields:
+                record.pop(unknown_field, None)
 
 
 def find_field_def(field_defs, field_id):

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -38,7 +38,6 @@ def bools_to_strings(records):
         for k, v in record.items():
             if isinstance(v, bool):
                 record[k] = str(v)
-    return records
 
 
 def remove_unknown_fields(record_fieldNames, payload, client_metadata):


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/5814

Adds a function to `services/records_to_socrata.py` to remove "illegal fields", fields that are in knack but are not in socrata (and should not be uploaded)

Also adds the configuration for travel-sensors.

Here is the corresponding airflow PR: cityofaustin/atd-airflow#51
Corresponding atd-data-deploy PR: cityofaustin/atd-data-deploy#87

**socrata:** https://data.austintexas.gov/Transportation-and-Mobility/Travel-Sensors/6yd9-yz2
**agol:** https://austin.maps.arcgis.com/home/item.html?id=9776d3e894a74521a7f63443f7becc7c
**knack:** https://atd.knack.com/amd#signal-queries/travel-sensors/
