### PR TITLE
5815 - add Signal Retiming to knack config

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -114,6 +114,7 @@ CONFIG = {
             "scene": "scene_375",
             "modified_date_field": "field_1257",
             "socrata_resource_id": "g8w2-8uap",
+        }
     },
     "signs-markings": {
         "view_3099": {

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -98,6 +98,13 @@ CONFIG = {
             "service_id": "47d17ff3ce664849a16b9974979cd12e",
             "layer_id": 0,
             "item_type": "layer",
+        },
+        "view_1063": {
+            "description": "Signal Retiming",
+            "scene": "scene_375",
+            "modified_date_field": "field_1257",
+            "socrata_resource_id": "g8w2-8uap",
+            "location_field_id": "", #"field_182",
         }
     },
     "signs-markings": {

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -104,7 +104,6 @@ CONFIG = {
             "scene": "scene_375",
             "modified_date_field": "field_1257",
             "socrata_resource_id": "g8w2-8uap",
-            "location_field_id": "", #"field_182",
         }
     },
     "signs-markings": {

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -40,16 +40,16 @@ def bools_to_strings(records):
                 record[k] = str(v)
 
 
-def remove_unknown_fields(record_fieldNames, payload, client_metadata):
+def remove_unknown_fields(payload, client_metadata):
     """
     Modifies payload by removing the fields not found in Socrata
     Prevents "400 Client Error: Bad Request. Illegal field name sent" response
-    :param record_fieldNames: list of fieldNames in knack dataset
     :param payload: records payload to send to Socrata
     :param client_metadata: Socrata metadata for app
     """
+    payload_fieldNames = payload[0].keys()
     column_names = [c["fieldName"] for c in client_metadata["columns"]]
-    unknown_fields = [fieldName.lower() for fieldName in record_fieldNames if fieldName.lower() not in column_names]
+    unknown_fields = [fieldName for fieldName in payload_fieldNames if fieldName not in column_names]
     if unknown_fields:
         logger.info(f"Record field names not in Socrata: {unknown_fields}")
         for record in payload:
@@ -146,7 +146,7 @@ def main():
     payload = [record.format() for record in records]
     payload = format_keys(payload)
     bools_to_strings(payload)
-    remove_unknown_fields(records[0].names(), payload, metadata_socrata)
+    remove_unknown_fields(payload, metadata_socrata)
     floating_timestamp_fields = utils.socrata.get_floating_timestamp_fields(
         resource_id, metadata_socrata
     )


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/5815

Adds configuration for Signal Retiming

Here is the corresponding airflow PR: cityofaustin/atd-airflow#52
Corresponding atd-data-deploy PR: cityofaustin/atd-data-deploy#89

**socrata:** https://data.austintexas.gov/Transportation-and-Mobility/Traffic-Signal-Re-Timing/g8w2-8uap
**knack:** https://atd.knack.com/amd#signal-queries/sync-cooridors-re-timings/
