### PR TITLE
4963 - add config for pole attachments

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -114,6 +114,16 @@ CONFIG = {
             "scene": "scene_375",
             "modified_date_field": "field_1257",
             "socrata_resource_id": "g8w2-8uap",
+        },
+        "view_1597": {
+            "description": "Pole Attachments",
+            "scene": "scene_589",
+            "modified_date_field": "field_1813",
+            "socrata_resource_id": "btg5-ebcy",
+            "location_field_id": "field_182",
+            "service_id": "3a5a777f780447db940534b5808d4ba7",
+            "layer_id": 0,
+            "item_type": "layer"
         }
     },
     "signs-markings": {


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/4963

Adds configuration for Pole Attachments

Here is the corresponding atd-airflow PR: https://github.com/cityofaustin/atd-airflow/pull/53
Corresponding atd-data-deploy PR: https://github.com/cityofaustin/atd-data-deploy/pull/90

**socrata:** https://data.austintexas.gov/dataset/Pole-Attachments/btg5-ebcy
**agol:** https://austin.maps.arcgis.com/home/item.html?id=3a5a777f780447db940534b5808d4ba7
**knack:** https://atd.knack.com/amd#pole-attachments2/