### PR TITLE
5910 -- add arterial management config

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -124,6 +124,15 @@ CONFIG = {
             "service_id": "3a5a777f780447db940534b5808d4ba7",
             "layer_id": 0,
             "item_type": "layer"
+        },
+        "view_1201": {
+            "description": "Arterial Management Locations",
+            "scene": "scene_425",
+            "modified_date_field": "field_508",
+            "location_field_id": "field_182",
+            "service_id": "66f4b5b0339d4275b64f265dd59727e5",
+            "layer_id": 0,
+            "item_type": "layer"
         }
     },
     "signs-markings": {


### PR DESCRIPTION
**Issue**: https://github.com/cityofaustin/atd-data-tech/issues/5910

Adds the config for arterial management

Here is the corresponding atd-airflow PR: cityofaustin/atd-airflow#54
There is no atd-data-deploy PR

**agol:** https://austin.maps.arcgis.com/home/item.html?id=66f4b5b0339d4275b64f265dd59727e5
**knack:** https://atd.knack.com/amd#signal-queries/locations-api/
