### PR TITLE
6208 - add signal cabinets to knack config

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -133,6 +133,16 @@ CONFIG = {
             "service_id": "66f4b5b0339d4275b64f265dd59727e5",
             "layer_id": 0,
             "item_type": "layer"
+        },
+        "view_1567": {
+            "description": "Signal Cabinets",
+            "scene": "scene_571",
+            "modified_date_field": "field_1793",
+            "socrata_resource_id": "x23u-shve",
+            "location_field_id": "field_1878",
+            "service_id": "c3fd3bb177cc4291880bbe8c630ed5c4",
+            "layer_id": 0,
+            "item_type": "layer"
         }
     },
     "signs-markings": {


### PR DESCRIPTION
Issue: cityofaustin/atd-data-tech#6208

Adds the config for signal cabinets

Here is the corresponding atd-airflow PR: cityofaustin/atd-airflow#56

socrata: https://data.austintexas.gov/Transportation-and-Mobility/Traffic-Signal-Cabinets/x23u-shve/
agol: https://austin.maps.arcgis.com/home/item.html?id=c3fd3bb177cc4291880bbe8c630ed5c4
knack: https://atd.knack.com/amd#signals-cabinets/