### PR TITLE
6676 - add socrata resource ids to signs & markings

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -146,6 +146,7 @@ CONFIG = {
             "layer_id": 1,
             "item_type": "layer",
             "location_field_id": None,
+            "socrata_resource_id": "nyhn-669r",
         },
         "view_3100": {
             "description": "Markings jobs",
@@ -155,6 +156,7 @@ CONFIG = {
             "layer_id": 0,
             "item_type": "layer",
             "location_field_id": None,
+            "socrata_resource_id": "vey3-7n3x",
         },
         "view_3096": {
             "description": "Markings work order attachments",
@@ -200,6 +202,7 @@ CONFIG = {
             "layer_id": 1,
             "item_type": "layer",
             "location_field_id": "field_3300",
+            "socrata_resource_id": "ivss-na93",
         },
         "view_3126": {
             "description": "Signs work order materials",
@@ -217,30 +220,12 @@ CONFIG = {
             "item_type": "table",
             "layer_id": 0,
         },
-        "view_3519": {
-            "description": "High Level Work Order Markings",
-            "scene": "scene_1407",
-            "modified_date_field": "field_2150",
-            "socrata_resource_id": "nyhn-669r",
-        },
-        "view_3521": {
-            "description": "High Level Work Order Markings Jobs",
-            "scene": "scene_1407",
-            "modified_date_field": "field_2150",
-            "socrata_resource_id": "vey3-7n3x",
-        },
         "view_3516": {
             "description": "High Level Work Order Signs Markings Time Logs",
             "scene": "scene_1407",
             "modified_date_field": "field_2150",
             "socrata_resource_id": "qvth-gwdv",
         },
-        "view_3518": {
-            "description": "High Level Work Orders Signs",
-            "scene": "scene_1407",
-            "modified_date_field": "field_2150",
-            "socrata_resource_id": "ivss-na93",
-        }
     },
     "finance-purchasing": {
         "view_788": {

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -217,6 +217,30 @@ CONFIG = {
             "item_type": "table",
             "layer_id": 0,
         },
+        "view_3519": {
+            "description": "High Level Work Order Markings",
+            "scene": "scene_1407",
+            "modified_date_field": "field_2150",
+            "socrata_resource_id": "nyhn-669r",
+        },
+        "view_3521": {
+            "description": "High Level Work Order Markings Jobs",
+            "scene": "scene_1407",
+            "modified_date_field": "field_2150",
+            "socrata_resource_id": "vey3-7n3x",
+        },
+        "view_3516": {
+            "description": "High Level Work Order Signs Markings Time Logs",
+            "scene": "scene_1407",
+            "modified_date_field": "field_2150",
+            "socrata_resource_id": "qvth-gwdv",
+        },
+        "view_3518": {
+            "description": "High Level Work Orders Signs",
+            "scene": "scene_1407",
+            "modified_date_field": "field_2150",
+            "socrata_resource_id": "ivss-na93",
+        }
     },
     "finance-purchasing": {
         "view_788": {

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -79,6 +79,8 @@ def patch_formatters(field_defs, location_field_id, metadata_socrata):
         formatter_func = utils.knack.socrata_formatter_point
     elif socrata_field_type == "location":
         formatter_func = utils.knack.socrata_formatter_location
+    elif socrata_field_type == "multipoint":
+        formatter_func = utils.knack.socrata_formatter_multipoint
     else:
         raise ValueError(
             f"Socrata data type for {location_field_id} ({field_name_knack}) is not a `point` or `location` type"  # noqa:E501

--- a/services/utils/knack.py
+++ b/services/utils/knack.py
@@ -17,6 +17,19 @@ def socrata_formatter_point(value):
     }
 
 
+def socrata_formatter_multipoint(value):
+    if not value:
+        return value
+
+    try:
+        return {
+            "type": "MultiPoint",
+            "coordinates": [[float(v["longitude"]), float(v["latitude"])] for v in value],
+        }
+    except ValueError:
+        return None
+
+
 def date_filter_on_or_after(timestamp, date_field, tzinfo="US/Central"):
     """Return a Knack filter to retrieve records on or after a given date field/value.
     If timestamp is None, defaults to 01/01/1970.

--- a/services/utils/knack.py
+++ b/services/utils/knack.py
@@ -18,6 +18,8 @@ def socrata_formatter_point(value):
 
 
 def socrata_formatter_multipoint(value):
+    # Location type: Multipoint
+    # https://dev.socrata.com/docs/datatypes/multipoint.html#,
     if not value:
         return value
 


### PR DESCRIPTION
Corresponding airflow PR: https://github.com/cityofaustin/atd-airflow/pull/60/

Surbhi's original document: https://docs.google.com/document/d/19C31MLIKiwFJobT8359sfJyYxHc0Mqa5v5_2jDXFUzQ/edit
Three of the views she listed are already being used in ETLs for arcgis online.

This PR adds another formatter function for socrata, `utils.knack.socrata_formatter_multipoint` to accommodate location fields with more than one location. 