### PR TITLE
Create signs/markings reimbursement config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ These services are designed to keep Knack application data in sync with external
 
 Incremental loading is made possible by referencing a record's timestamp throughout the pipleine. Specifically:
 
-- The [Knack configuration file](#knack-config) requires that all entries include a `modified_date_field_id`. This field must be exposed in the source container and must be configured in the Knack application to reliably maintain the datetime at which a record was last modified. Note that Knack does not have built-in funcionality to achieve this—it is incumbent upon the application builder to configure app rules accordingly.
+- The [Knack configuration file](#knack-config) allows for a `modified_date_field`. This field must be exposed in the source container and must be configured in the Knack application to reliably maintain the datetime at which a record was last modified. Note that Knack does not have built-in funcionality to achieve this—it is incumbent upon the application builder to configure app rules accordingly.
 
 - The [Postgres data store](#postgres-data-store) relies on a stored procedure to maintain an `updated_at` timestamp which is set to the current datetime whenever a record is created or modified.
 
@@ -130,7 +130,7 @@ CONFIG = {
 #### Container properties
 
 - `scene` (`str`): If the container is a Knack view, this is required, and refers to the Knack scene ID which contains the view.
-- `modified_date_field` (`str`, required): A knack field ID (e.g., `field_123`) which defines when each record was last modified. This field will be used to filter records for each ETL run.
+- `modified_date_field` (`str`, optional): A knack field ID (e.g., `field_123`) which defines when each record was last modified. If provided, this field will be used to filter records for each ETL run.
 - `description` (`str`, optional): a description of what kind of record this container holds.
 - `socrata_resource_id` (`str`, optional): The Socrata resource ID of the destination dataset. This is required if publshing to Socrata.
 - `location_field_id` (`str`, optional): The field key which will be translated to Socrata "location" field types or an ArcGIS Online point geometry.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ CONFIG = {
 #### Container properties
 
 - `scene` (`str`): If the container is a Knack view, this is required, and refers to the Knack scene ID which contains the view.
-- `modified_date_field` (`str`, optional): A knack field ID (e.g., `field_123`) which defines when each record was last modified. If provided, this field will be used to filter records for each ETL run.
+- `modified_date_field` (`str`, optional): A knack field ID (e.g., `field_123`) which defines when each record was last modified. If provided, this field will be used to filter records for each ETL run. If not provided, all records will always be fetched/processed from the source Knack container.
 - `description` (`str`, optional): a description of what kind of record this container holds.
 - `socrata_resource_id` (`str`, optional): The Socrata resource ID of the destination dataset. This is required if publshing to Socrata.
 - `location_field_id` (`str`, optional): The field key which will be translated to Socrata "location" field types or an ArcGIS Online point geometry.

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -232,6 +232,8 @@ CONFIG = {
         # similar views, one with connection fields added from markings and the other with fields
         # added from signs. They map one set of columns in Socrata, which matches on the knack field
         # name rather than key.
+        # note also that they do not have a "modified_date_field". As a result all records will always
+        # be processes. OK in this case since they accumulate at ~500/year.
         "view_3526": {
             "description": "Signs reimburesement tracking",
             "scene": "scene_1249",

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -220,11 +220,27 @@ CONFIG = {
             "item_type": "table",
             "layer_id": 0,
         },
-        "view_3516": {
+        "view_3307": {
             "description": "High Level Work Order Signs Markings Time Logs",
-            "scene": "scene_1407",
+            "scene": "scene_1249",
             "modified_date_field": "field_2150",
             "socrata_resource_id": "qvth-gwdv",
+        },
+        # Note that views 3526 and 3527 push to the same socrata dataset. This object is a child to
+        # both work_orders_markings and work_orders_signs - which share duplicate field names, notably
+        # ATD_WORK_ORDER_ID, WORK_TYPE, and LOCATION_NAME. So we source the reimbursements from two
+        # similar views, one with connection fields added from markings and the other with fields
+        # added from signs. They map one set of columns in Socrata, which matches on the knack field
+        # name rather than key.
+        "view_3526": {
+            "description": "Signs reimburesement tracking",
+            "scene": "scene_1249",
+            "socrata_resource_id": "pma8-yy5k",
+        },
+        "view_3527": {
+            "description": "Markings reimburesement tracking",
+            "scene": "scene_1249",
+            "socrata_resource_id": "pma8-yy5k",
         },
     },
     "finance-purchasing": {

--- a/services/records_to_postgrest.py
+++ b/services/records_to_postgrest.py
@@ -67,7 +67,7 @@ def main():
             f"No config entry found for app: {args.app_name}, container: {container}"
         )
 
-    modified_date_field = app_config["modified_date_field"]
+    modified_date_field = app_config.get("modified_date_field")
 
     filters = utils.knack.date_filter_on_or_after(
         args.date, modified_date_field, tzinfo=APP_TIMEZONE

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -155,9 +155,10 @@ def main():
     # apply transforms to meet socrata's expectations
     payload = [record.format() for record in records]
     payload = format_keys(payload)
+    # remove unknown fields first to reduce extra processing when doing subsequent transforms
+    remove_unknown_fields(payload, metadata_socrata)
     bools_to_strings(payload)
     handle_arrays(payload)
-    remove_unknown_fields(payload, metadata_socrata)
     floating_timestamp_fields = utils.socrata.get_floating_timestamp_fields(
         resource_id, metadata_socrata
     )

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -55,9 +55,9 @@ def remove_unknown_fields(payload, client_metadata):
     :param payload: records payload to send to Socrata
     :param client_metadata: Socrata metadata for app
     """
-    payload_fieldNames = payload[0].keys()
+    payload_field_names = payload[0].keys()
     column_names = [c["fieldName"] for c in client_metadata["columns"]]
-    unknown_fields = [fieldName for fieldName in payload_fieldNames if fieldName not in column_names]
+    unknown_fields = [field_name for field_name in payload_field_names if field_name not in column_names]
     if unknown_fields:
         logger.info(f"Record field names not in Socrata: {unknown_fields}")
         for record in payload:

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -40,6 +40,14 @@ def bools_to_strings(records):
                 record[k] = str(v)
 
 
+def handle_arrays(records):
+    for record in records:
+        for k, v in record.items():
+            if isinstance(v, list):
+                # assumes values in list can be coerced to to strings
+                record[k] = ", ".join([str(i) for i in v])
+
+
 def remove_unknown_fields(payload, client_metadata):
     """
     Modifies payload by removing the fields not found in Socrata
@@ -148,6 +156,7 @@ def main():
     payload = [record.format() for record in records]
     payload = format_keys(payload)
     bools_to_strings(payload)
+    handle_arrays(payload)
     remove_unknown_fields(payload, metadata_socrata)
     floating_timestamp_fields = utils.socrata.get_floating_timestamp_fields(
         resource_id, metadata_socrata

--- a/services/utils/knack.py
+++ b/services/utils/knack.py
@@ -34,7 +34,6 @@ def socrata_formatter_multipoint(value):
 
 def date_filter_on_or_after(timestamp, date_field, tzinfo="US/Central"):
     """Return a Knack filter to retrieve records on or after a given date field/value.
-    If timestamp is None, defaults to 01/01/1970.
 
     You should know:
     - Knack ignores time when querying by date. So we drop it when formatting the
@@ -46,13 +45,10 @@ def date_filter_on_or_after(timestamp, date_field, tzinfo="US/Central"):
     - Knack is completely timezone naive. If you provide a date, it assumes the date
     is referencing the same locality to which the Knack app is configured.
     """
-    date_str = timestamp or 0
+    if not timestamp or not date_field:
+        return None
 
-    date_str = (
-        arrow.get(timestamp).to(tzinfo).format("MM/DD/YYYY")
-        if timestamp
-        else "01/01/1970"
-    )
+    date_str = arrow.get(timestamp).to(tzinfo).format("MM/DD/YYYY")
 
     return {
         "match": "or",


### PR DESCRIPTION
Towards closing [#3114](https://github.com/cityofaustin/atd-data-tech/issues/3114).

- adds config for signs and markings reimbursements to Socrata
- moves signs markings time log config to a view in the same scene as the related signs-markings API views
- adds records_to_socrata handler to transform lists into strings. this was needed to handle one-many fields for street segment attributes ([#6637](https://github.com/cityofaustin/atd-data-tech/issues/6637))
- removes requirement for Knack config to have a `modified_date_field` parameter. If field is not present, no date filter will be applied and all records fill be processed.