### PR TITLE
Use correct time log modified date in Knack config

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -223,7 +223,7 @@ CONFIG = {
         "view_3307": {
             "description": "High Level Work Order Signs Markings Time Logs",
             "scene": "scene_1249",
-            "modified_date_field": "field_2150",
+            "modified_date_field": "field_2559",
             "socrata_resource_id": "qvth-gwdv",
         },
         # Note that views 3526 and 3527 push to the same socrata dataset. This object is a child to


### PR DESCRIPTION
I noticed that the time logs DAG was processing every record on every DAG run. It turns out that the modified date specified in the config does not exist in the view—it references the modified date of markings work orders. I updated the config to reference the time log modified date field.

It's annoying that the Knack API does not through an error here. It just quietly ignores the filter params in the API request :/ 