### PR TITLE
Pin PostgreSQL docker image to version 13 for the local dev env

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres
+    image: postgres:13
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
PostgreSQL V14 introduces a breaking change with the latest version of postgREST (8.0.0), which prevents standing up a local development environment. The postgREST team appears to have [addressed the issue](https://github.com/PostgREST/postgrest/issues/1857) recently, and presumably this remediation will be out in the next release.

This change pins the PostgreSQL version coming out of dockerhub at v13, which should be sufficient for the purposes of this application. 