### PR TITLE
format agol keys like socrata, use shared util

### DIFF
--- a/services/utils/agol.py
+++ b/services/utils/agol.py
@@ -1,3 +1,6 @@
+from . import shared
+
+
 def sanitize_html(record, field_names):
     """
     Temporary hack until we disable html content validation on feature services
@@ -48,6 +51,9 @@ def build_feature(
 ):
     feature = {}
     feature["attributes"] = sanitize_html(record.format(), fields_names_to_sanitize)
+    # format knack field names as lowercase/no spaces
+    feature["attributes"] = shared.format_keys(feature["attributes"])
+    # handle geometry
     if location_field_id:
         record_geometry = record[location_field_id]
         if not record_geometry:
@@ -62,7 +68,7 @@ def build_feature(
 
 
 def handle_response(response):
-    """ arcgis does not raise HTTP errors for data-related issues; we must manually
+    """arcgis does not raise HTTP errors for data-related issues; we must manually
     parse the response"""
     if not response:
         return

--- a/services/utils/shared.py
+++ b/services/utils/shared.py
@@ -1,0 +1,4 @@
+def format_keys(record):
+    """Format Knack record keys by converting to lower case and replacing space
+    with underscores"""
+    return {key.lower().replace(" ", "_"): val for key, val in record.items()}


### PR DESCRIPTION
Applies the same field name formatting scheme to AGOL records as we do for Socrata records. (Replace spaces with underscores and make fields lowercase)

This came up when I was working on https://github.com/cityofaustin/atd-data-tech/issues/8032