### PR TITLE
Trigger build on push or pull on prod

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -3,8 +3,11 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [production, staging]
-
+    branches:
+      - production
+  pull_request:
+    branches:
+      - production
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Based on "discussion" [here](https://github.com/cityofaustin/atd-knack-services/pull/93#issuecomment-1001645803), I've removed the staging branch.

@chiaberry this PR updates the docker build action so that any merge to or pull request on production will trigger a new build. This will have the effect of pushing to Airflow the image from any PR. I think this is what we want, so that we can test it?

Alternatively, we could only build a new image on merge to prod. In which case you have to rely on testing locally (presumably w/o Airflow). I actually think that behavior might be better/more transparent?