### PR TITLE
Add new optional socrata features for running inventory log

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ CONFIG = {
 - `layer_id` (`int`, optional): The ArcGIS Online layer ID of the the destination layer in the feature service.
 - `item_type` (`str`, optional): The type ArcGIS Online layer. Must be either `layer` or `table`.
 - `dest_apps` (`dict`, optional): Destination app information for [publishing to another knack app](#publish-records-to-another-knack-app)
+- `no_replace_socrata` (`bool`, optional): If true, blocks a `replace` operation on the destination Socrata dataset.
 
 ## Services (`/services`)
 
@@ -214,7 +215,8 @@ $ python records_to_socrata.py \
 
 - `--app-name, -a` (`str`, required): the name of the source Knack application
 - `--container, -c` (`str`, required): the object or view key of the source container
-- `--date, -d` (`str`, optional): an ISO-8601-compliant date string. If no timezone is provided, GMT is assumed. Only records which were modified at or after this date will be processed. If excluded, all records will be processed.
+- `--date, -d` (`str`, optional): an ISO-8601-compliant date string. If no timezone is provided, GMT is assumed. Only records which were modified at or after this date will be processed. If excluded, all records will be processed and the destination dataset will be
+*completely replaced*.
 
 ### Publish records to ArcGIS Online
 
@@ -243,7 +245,8 @@ $ python records_to_agol.py \
 
 - `--app-name, -a` (`str`, required): the name of the source Knack application
 - `--container, -c` (`str`, required): the object or view key of the source container
-- `--date, -d` (`str`, optional): an ISO-8601-compliant date string. If no timezone is provided, GMT is assumed. Only records which were modified at or after this date will be processed. If excluded, all records will be processed.
+- `--date, -d` (`str`, optional): an ISO-8601-compliant date string. If no timezone is provided, GMT is assumed. Only records which were modified at or after this date will be processed. If excluded, all records will be processed and the destination dataset will be
+*completely replaced*.
 
 ### Publish records to another Knack app
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ CONFIG = {
 - `item_type` (`str`, optional): The type ArcGIS Online layer. Must be either `layer` or `table`.
 - `dest_apps` (`dict`, optional): Destination app information for [publishing to another knack app](#publish-records-to-another-knack-app)
 - `no_replace_socrata` (`bool`, optional): If true, blocks a `replace` operation on the destination Socrata dataset.
+- `append_timestamps_socrata` (`dict` (`{'key': <timestamp_column_name> (str)}`>, optional): If present, a current timestamp will be added to each record at the given column name `key`.
 
 ## Services (`/services`)
 

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -45,7 +45,7 @@ CONFIG = {
             "modified_date_field": "field_1229",
             "socrata_resource_id": "hcaw-evi2",
             "append_timestamps": {"key": "published_date"},
-            "no_replace": True
+            "no_replace_socrata": True
         },
         "view_2908": {
             "description": "Metrobike kiosks",

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -44,7 +44,7 @@ CONFIG = {
             "scene": "scene_1170",
             "modified_date_field": "field_1229",
             "socrata_resource_id": "hcaw-evi2",
-            "append_timestamps": {"key": "published_date"},
+            "append_timestamps_socrata": {"key": "published_date"},
             "no_replace_socrata": True
         },
         "view_2908": {

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -40,9 +40,12 @@ CONFIG = {
             "location_field_id": "field_182",
         },
         "view_2863": {
-            "description": "Inventory items",
+            "description": "Inventory items (finance system integration + socrata pub)",
             "scene": "scene_1170",
             "modified_date_field": "field_1229",
+            "socrata_resource_id": "hcaw-evi2",
+            "append_timestamps": {"key": "published_date"},
+            "no_replace": True
         },
         "view_2908": {
             "description": "Metrobike kiosks",
@@ -99,7 +102,7 @@ CONFIG = {
             "location_field_id": "field_182",
             "service_id": "9776d3e894a74521a7f63443f7becc7c",
             "layer_id": 0,
-            "item_type": "layer"
+            "item_type": "layer",
         },
         "view_1063": {
             "description": "Signal Retiming",
@@ -115,7 +118,7 @@ CONFIG = {
             "location_field_id": "field_182",
             "service_id": "3a5a777f780447db940534b5808d4ba7",
             "layer_id": 0,
-            "item_type": "layer"
+            "item_type": "layer",
         },
         "view_1201": {
             "description": "Arterial Management Locations",
@@ -124,7 +127,7 @@ CONFIG = {
             "location_field_id": "field_182",
             "service_id": "66f4b5b0339d4275b64f265dd59727e5",
             "layer_id": 0,
-            "item_type": "layer"
+            "item_type": "layer",
         },
         "view_1567": {
             "description": "Signal Cabinets",
@@ -134,14 +137,14 @@ CONFIG = {
             "location_field_id": "field_1878",
             "service_id": "c3fd3bb177cc4291880bbe8c630ed5c4",
             "layer_id": 0,
-            "item_type": "layer"
+            "item_type": "layer",
         },
         "view_3003": {
             "description": "Signal detection status logs",
             "scene": "scene_514",
             "modified_date_field": "field_2565",
-            "socrata_resource_id": "e4b6-xseb"
-        }
+            "socrata_resource_id": "e4b6-xseb",
+        },
     },
     "signs-markings": {
         "view_3099": {

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -164,7 +164,15 @@ def main():
     if timestamp_key:
         utils.socrata.append_current_timestamp(payload, timestamp_key)
 
-    method = "replace" if not args.date and not config.get("no_replace") else "upsert"
+    method = "replace" if not args.date else "upsert"
+
+    if config.get("no_replace_socrata") and method == "replace":
+        raise ValueError(
+            """
+            Replacement of this Socrata dataset is not allowed. Specify a date range or
+            modify the 'no_replace_socrata' setting in this container's config.
+            """
+        )
 
     utils.socrata.publish(
         method=method, resource_id=resource_id, payload=payload, client=client_socrata

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -159,7 +159,12 @@ def main():
     )
     handle_floating_timestamps(payload, floating_timestamp_fields)
 
-    method = "upsert" if args.date else "replace"
+    timestamp_key = config.get("append_timestamps", {}).get("key")
+
+    if timestamp_key:
+        utils.socrata.append_current_timestamp(payload, timestamp_key)
+
+    method = "replace" if not args.date and not config.get("no_replace") else "upsert"
 
     utils.socrata.publish(
         method=method, resource_id=resource_id, payload=payload, client=client_socrata

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -159,7 +159,7 @@ def main():
     )
     handle_floating_timestamps(payload, floating_timestamp_fields)
 
-    timestamp_key = config.get("append_timestamps", {}).get("key")
+    timestamp_key = config.get("append_timestamps_socrata", {}).get("key")
 
     if timestamp_key:
         utils.socrata.append_current_timestamp(payload, timestamp_key)

--- a/services/utils/socrata.py
+++ b/services/utils/socrata.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 import os
 
+import arrow
 import sodapy
 
 
@@ -21,6 +23,25 @@ def get_floating_timestamp_fields(resource_id, metadata):
     ]
 
 
+def append_current_timestamp(records, key, tzinfo="US/Central", format_="YYYY-MM-DDTHH:mm:ss"):
+    """Appends an ISO-8601 timestamp to each record.
+
+    The timestamp is created in US/Central time without the tz string. This
+    is unfortunately the socrata way.
+
+    Args:
+        records (list): A list of record dicts
+        key (str): The key which will be added to each record dict with the timestamp value
+        format_ (str): The arrow formatting token string 
+
+    Returns:
+        None: the records are updated in place.
+    """
+    now = arrow.now().to(tzinfo).format(format_)
+    for record in records:
+        record[key] = now
+
+
 def get_client(host="data.austintexas.gov", timeout=30):
     SOCRATA_APP_TOKEN = os.getenv("SOCRATA_APP_TOKEN")
     SOCRATA_API_KEY_ID = os.getenv("SOCRATA_API_KEY_ID")
@@ -31,7 +52,7 @@ def get_client(host="data.austintexas.gov", timeout=30):
         SOCRATA_APP_TOKEN,
         username=SOCRATA_API_KEY_ID,
         password=SOCRATA_API_KEY_SECRET,
-        timeout=timeout
+        timeout=timeout,
     )
 
 


### PR DESCRIPTION
In service of https://github.com/cityofaustin/atd-data-tech/issues/7581.

### Background

This issue ☝️ is asking for a daily snapshot of a Knack view of inventory items. The approach I've settled on is to simply append rows to a Socrata dataset on a daily basis, and pair that with a [PowerBI dashboard](https://github.com/cityofaustin/atd-data-tech/issues/8212) to interact with the data.

This can be accomplished purely through the Socrata dataset configuration, by **not** setting a [row identifier](https://support.socrata.com/hc/en-us/articles/360008065493) on the dataset. When no row identifier is configured, any attempt to upsert to the dataset will result in an insert, thereby appending rows to the dataset.

So we can use atd-knack-services to accomplish this, with a few minor enhancements:

1. For reporting purposes, we need a way to distinguish duplicate rows by the date of their snapshot. And so I've added an optional container config property, `append_timestamps_socrata`, which appends a timestamp value to each record before publishing to Socrata.

2. Because we're not storing these snapshots anywhere other than the dataset itself, there is a risk that this dataset could get accidentally overwritten and the historical record would be lost. Eek. I have taken a bit of shortcut here by adding an optional container config property, `no_replace_socrata`, which prevents a `replace` operation on the destination dataset. (W/o this change, a replace action is automatically triggered when ever `records_to_socrata.py` is run without a `--date` argument.)

I don't feel super awesome about choice `#2`. A more resilient solution would be to set up a proper pipeline where snapshots of the Knack view are archived in S3, and then piped into Socrata. That's a fairly well-worn pattern, but we're talking about a whole separate set of tooling to manage this one report :/ 

The reason I'm ok with this current approach is that the report—the quantity of inventory on hand, per item, on an arbitrary day—can be re-constructed through the inventory system's transaction log fairly easily. So on the off chance that this Socrata dataset were corrupted, we could rebuild it.

Thanks for reading this. I'd appreciate your feedback!

