### PR TITLE
Check socrata types when converting bools to strings

### DIFF
--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -27,13 +27,14 @@ def get_boolean_columns(client_metadata):
     return [
         col["fieldName"]
         for col in client_metadata["columns"]
+        # boolean fields in socrata are type "checkbox"
         if col["dataTypeName"] == "checkbox"
     ]
 
 
 def bools_to_strings(records, boolean_columns):
     """Convert booleans from knack to strings
-    Some Socrata datasets have been been created with type mistmatch b/t Knack and Socrata,
+    Some Socrata datasets have been been created with type mismatch b/t Knack and Socrata,
     where a boolean field in Knack is configured as a text field in Socrata.
     This function converts a Knack boolean to a string.
 

--- a/services/utils/socrata.py
+++ b/services/utils/socrata.py
@@ -23,7 +23,9 @@ def get_floating_timestamp_fields(resource_id, metadata):
     ]
 
 
-def append_current_timestamp(records, key, tzinfo="US/Central", format_="YYYY-MM-DDTHH:mm:ss"):
+def append_current_timestamp(
+    records, key, tzinfo="US/Central", format_="YYYY-MM-DDTHH:mm:ss"
+):
     """Appends an ISO-8601 timestamp to each record.
 
     The timestamp is created in US/Central time without the tz string. This
@@ -32,7 +34,7 @@ def append_current_timestamp(records, key, tzinfo="US/Central", format_="YYYY-MM
     Args:
         records (list): A list of record dicts
         key (str): The key which will be added to each record dict with the timestamp value
-        format_ (str): The arrow formatting token string 
+        format_ (str): The arrow formatting token string
 
     Returns:
         None: the records are updated in place.


### PR DESCRIPTION
Towards fixing https://github.com/cityofaustin/atd-data-tech/issues/9985

Our Socrata datasets have been been created with type mismatch b/t Knack and Socrata, where a boolean field in Knack is configured as a text field in Socrata. 

Rather than retroactively fixing those poorly configured datasets, we have continued to use text fields in Socrata where booleans should be used, and our `records_to_socrata` script would convert any and all booleans in the Knack payload to strings.

This PR updates the `bools_to_string` function to selectively convert bools to strings based on the column type in Socrata. It is backwards compatible, and going forward we can configure Socrata datasets with actual boolean types.