### PR TITLE
Update build versions and remove reference to staging

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -3,7 +3,8 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [production, staging]
+    branches:
+      - production
 
 jobs:
   main:
@@ -11,17 +12,17 @@ jobs:
     steps:
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: |


### PR DESCRIPTION
- removes `staging` branch action - we deleted the staging branch a while ago
- bumps docker build action versions
- uses a new repo-specific token i've added to the repo's secrets