### PR TITLE
Asset type for unmatched locations

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -42,7 +42,7 @@ CONFIG = {
         },
         "view_2362":{
             "description": "MMC Issue Auto Assign Queue",
-            "scene":"scene_514",
+            "scene": "scene_514",
             "modified_date_field": "field_1385",
             "object": "object_83", # Needed for sr_asset_assign
             "assign_status_field_id": "field_2813", # Needed for sr_asset_assign

--- a/services/sr_asset_assign.py
+++ b/services/sr_asset_assign.py
@@ -204,7 +204,7 @@ def main(args):
             if not res["features"]:
                 # Only need to send the status no_asset_found
                 record[status_field] = "no_asset_found"
-                record[config["asset_type_field_id"]] = ""
+                record[config["asset_type_field_id"]] = "No Asset / Unkown Location / Other"
                 record[connected_field] = ""
                 logger.info(f"No Assets found for ID: {record['id']}.")
             elif len(res["features"]) != 1:


### PR DESCRIPTION
Got a few of these errors getting raised for quite a while in the ETL:
```
No Assets found for ID: 641f4f2b14bf1f00288fe904.
{"errors":[{"field":"field_1649","type":"required","message":"ASSET_TYPE is required."}]}
```
`ASSET_TYPE` is a multiple choice type so we have to send a valid selection for that field. I'm setting it to the "No Asset / Unkown Location / Other" option (yes it is correctly misspelled).