### PR TITLE
Timestamp bug and Reducing errors

### DIFF
--- a/services/knack_street_seg_updater.py
+++ b/services/knack_street_seg_updater.py
@@ -144,10 +144,14 @@ def main(args):
         features = query_atx_street(
             street_segment[config["primary_key"]], token
         )
-        time.sleep(1) # wait one second between requests to prevent being rate limited
         if features.get("error"):
             # AGOL returns code 200 even for error queries.
-            raise Exception(str(features))
+            # Let's try the query again
+            features = query_atx_street(
+                street_segment[config["primary_key"]], token
+            )
+            if features.get("error"):
+                raise Exception(str(features))
 
         # handling returned segment features from AGOL
         if features.get("features"):

--- a/services/utils/knack.py
+++ b/services/utils/knack.py
@@ -48,7 +48,7 @@ def date_filter_on_or_after(timestamp, date_field, tzinfo="US/Central", use_time
         return None
 
     if use_time:
-        date_str = arrow.get(timestamp).to(tzinfo).format("MM/DD/YYYY HH:MM")
+        date_str = arrow.get(timestamp).to(tzinfo).format("MM/DD/YYYY HH:mm")
     else:
         date_str = arrow.get(timestamp).to(tzinfo).format("MM/DD/YYYY")
 


### PR DESCRIPTION
Pretty frequently while running this locally on a batch of street segments this will error with a timeout or unknown error from AGOL. This change gives each segment a second chance before raising an error. 

Also, I was accidentally coding month num as the minute in querying our knack data. 