### PR TITLE
Segment Updater: check for no data earlier

### DIFF
--- a/services/knack_street_seg_updater.py
+++ b/services/knack_street_seg_updater.py
@@ -133,12 +133,11 @@ def main(args):
     app = knackpy.App(app_id=APP_ID, api_key=API_KEY)
     records = app.get(container, filters=filters)
     records_formatted = [record.format() for record in records]
-    field_mapping = create_knack_field_mapping(records[0])
-
     if not records_formatted:
         logger.info('No records to update. Doing nothing.')
         return 0
-
+    field_mapping = create_knack_field_mapping(records[0])
+    
     unmatched_segments = []
     for street_segment in records_formatted:
         features = query_atx_street(


### PR DESCRIPTION
Noise over the weekend in the ETL:
```
line 136, in main   field_mapping = create_knack_field_mapping(records[0])\nIndexError: list index out of range\n'
```

knackpy uses a filter for the `modified_date` field greater than last execution datetime.  So, no data was being returned from Knack, as expected for the weekend where things are pretty static.
It was erroring out before being caught by `if not records_formatted:`. Just moving that up before the field mapping part. 