### PR TITLE
SR Asset Assign: Use form view to update records

### DIFF
--- a/services/config/locations.py
+++ b/services/config/locations.py
@@ -7,11 +7,10 @@ ASSET_CONFIG = {
         "display_name": "Signal",
         "layer": {
             "service_name": "TRANSPORTATION_signals2",
-            "outFields": "SIGNAL_ID",
+            "outFields": "id",
             "layer_id": 0,
             "distance": 10,
             "units": "esriSRUnit_Foot",
-            "primary_key": "SIGNAL_ID",
         },
     },
 }

--- a/services/sr_asset_assign.py
+++ b/services/sr_asset_assign.py
@@ -15,8 +15,8 @@ APP_ID = os.getenv("KNACK_APP_ID")
 API_KEY = os.getenv("KNACK_API_KEY")
 AGOL_USER = os.getenv("AGOL_USERNAME")
 AGOL_PASS = os.getenv("AGOL_PASSWORD")
-KNACK_API_USER_EMAIL = os.getenv("AGOL_PASSWORD")
-KNACK_API_USER_PW = os.getenv("AGOL_PASSWORD")
+KNACK_API_USER_EMAIL = os.getenv("KNACK_API_USER_EMAIL")
+KNACK_API_USER_PW = os.getenv("KNACK_API_USER_PW")
 
 
 def create_agol_login_token():


### PR DESCRIPTION
- https://github.com/cityofaustin/atd-data-tech/issues/12301

This PR updates this script to use a form view to update records. We used to do this in [the legacy](https://github.com/cityofaustin/atd-data-publishing/blob/c4f79fc28d6aa437d103e835ead58915d89cb5cf/transportation-data-publishing/data_tracker/sr_asset_assign.py#L47) and it ensures some Knack business rules run after we submit our updates.

If you wanted to do test this you could patch in the credentials for the [Data Tracker ESB test environment](https://builder.knack.com/atd/austin-transportation-data-tracker-esb-test-environment-20). That's what I did and I think we should deploy this.