### PR TITLE
Use id column for query ordering

### DIFF
--- a/services/records_to_agol.py
+++ b/services/records_to_agol.py
@@ -88,7 +88,7 @@ def main():
             "container_id": f"eq.{container}",
             "updated_at": f"gte.{filter_iso_date_str}",
         },
-        order_by="record_id",
+        order_by="id",
     )
 
     logger.info(f"{len(data)} to process.")

--- a/services/records_to_knack.py
+++ b/services/records_to_knack.py
@@ -111,7 +111,7 @@ def main():
             "container_id": f"eq.{container_src}",
             "updated_at": f"gte.{filter_iso_date_str}",
         },
-        order_by="record_id",
+        order_by="id",
     )
 
     logger.info(f"{len(data_src)} records to process")
@@ -130,7 +130,7 @@ def main():
             "app_id": f"eq.{APP_ID_DEST}",
             "container_id": f"eq.{container_dest}",
         },
-        order_by="record_id",
+        order_by="id",
     )
 
     data_src = [r["record"] for r in data_src]

--- a/services/records_to_socrata.py
+++ b/services/records_to_socrata.py
@@ -147,7 +147,7 @@ def main():
             "container_id": f"eq.{container}",
             "updated_at": f"gte.{filter_iso_date_str}",
         },
-        order_by="record_id",
+        order_by="id",
     )
 
     logger.info(f"{len(data)} records to process")


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/12947.

I've added a unique `bigint` serial column to the knack records table in postgREST. This PR updates the ETL scripts to paginate based on this column, rather than using the text `record_id`. This should offer a significant improvement in query performance and was definitely an oversight on my part not setting this up in the first place.

To test this, you'll need to set up a python env with the necessary requirements, or mount this branch into your Docker image:

```
# e.g., traffic signals to AGOL
docker run -it --rm --env-file env_file -v /My/path/to/atd-knack-services:/app atddocker/atd-knack-services:production ./atd-knack-services/services/records_to_agol.py -a data-tracker -c view_395
```
