### PR TITLE
Secondary Signals Maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ ATD Knack Services is a set of python modules which automate the flow of data fr
   - [Publish to another Knack app](#publish-records-to-another-knack-app)
   - [Knack Maintenance: 311 SR Auto Asset Assign](#knack-maintenance-311-sr-auto-asset-assign)
   - [Knack maintenance: Update location fields in Knack based on AGOL layers](#knack-maintenance-update-location-fields-in-knack-based-on-agol-layers)
+  - [Knack maintenance: Street Segment Updater](#knack-maintenance-street-segment-updater)
+  - [Knack maintenance: Secondary Signals Updater](knack-maintenance-secondary-signals-updater)
 - [Utils](<#utils-(`/services/utils`)>)
 - [Common Tasks](#common-tasks)
   - [Configure a Knack container](#configuring-a-knack-container)
@@ -487,6 +489,49 @@ CONFIG =
 - `--container, -c` (`str`, required): the object or view key of the source container
 - `--date, -d` (`str`, optional): an ISO-8601-compliant date string. **Also supports time in UTC**, time is then converted into local knack app time. If no time is provided midnight UTC is assumed. Only records which were modified at or after this date will be processed. If excluded, all records will be processed and the destination dataset will be
   _completely replaced_.
+
+### Knack maintenance: Secondary Signals Updater
+
+Propagates updates to secondary-to-primary signal relationships. This script updates the `SECONDARY_SIGNALS` field
+when changes are detected in the `PRIMARY_SIGNAL` field to reduce overhead of needing AMD staff needing to maintain both
+sides of this primary-secondary relationship and prevents de-sycning.
+
+#### Configuration
+
+`app-name`,`view`, `scene`, and `object` of the traffic signal table are the configuration items are required in `config/knack.py`.  
+
+```python
+CONFIG = {
+    "data-tracker":{
+        "view_197": {
+            "description": "Signals data pub view",
+            "scene": "scene_73",
+            "object": "object_12",
+        },
+    }
+}
+```
+
+In `config/field_maps.py`, some knack field definitions are required. The field of the primary signal relationship and 
+the field of the secondary signal field. Along with the field that is going to be updated by the script.
+
+```python
+SECONDARY_SIGNALS = {
+    "data-tracker": {
+        "view_197": {
+            "SECONDARY_SIGNALS": "field_1329_raw",  
+            "PRIMARY_SIGNAL": "field_1121_raw",  
+            "update_field": "field_1329", 
+        }
+    }
+}
+```
+
+
+#### CLI arguments
+
+- `--app-name, -a` (`str`, required): the name of the source Knack application
+- `--container, -c` (`str`, required): the object or view key of the source container
 
 ## Utils (`/services/utils`)
 

--- a/services/config/field_maps.py
+++ b/services/config/field_maps.py
@@ -57,20 +57,11 @@ FIELD_MAPS = {
                 "handler": handle_strip,
             },
             # Signal Status
-            {
-                "src": "field_491",
-                "smart-mobility": "field_383",
-            },
+            {"src": "field_491", "smart-mobility": "field_383",},
             # Modified Date/time
-            {
-                "src": "field_205",
-                "smart-mobility": "field_391",
-            },
+            {"src": "field_205", "smart-mobility": "field_391",},
             # Location ID
-            {
-                "src": "field_209",
-                "smart-mobility": "field_381",
-            },
+            {"src": "field_209", "smart-mobility": "field_381",},
             # Council district
             {
                 "src": "field_189_raw",
@@ -78,50 +69,25 @@ FIELD_MAPS = {
                 "handler": handle_multiple_choice,
             },
             # Signal Name
-            {
-                "src": "field_1058",
-                "smart-mobility": "field_386",
-            },
+            {"src": "field_1058", "smart-mobility": "field_386",},
             # Signal Engineer Area
-            {
-                "src": "field_188_raw",
-                "smart-mobility": "field_387",
-            },
+            {"src": "field_188_raw", "smart-mobility": "field_387",},
         ],
     },
     "finance-purchasing": {
         "view_788": [
             # ATD_INVENTORY_ID
-            {
-                "src": "field_918",
-                "data-tracker": "field_3812",
-                "primary_key": True,
-            },
+            {"src": "field_918", "data-tracker": "field_3812", "primary_key": True,},
             #  STOCK_NUMBER
-            {
-                "src": "field_720",
-                "data-tracker": "field_3467",
-            },
+            {"src": "field_720", "data-tracker": "field_3467",},
             #  CATEGORY
-            {
-                "src": "field_363",
-                "data-tracker": "field_243",
-            },
+            {"src": "field_363", "data-tracker": "field_243",},
             #  Financial Name
-            {
-                "src": "field_364",
-                "data-tracker": "field_244",
-            },
+            {"src": "field_364", "data-tracker": "field_244",},
             # Common Name
-            {
-                "src": "field_914",
-                "data-tracker": "field_3617",
-            },
+            {"src": "field_914", "data-tracker": "field_3617",},
             # Modified Date
-            {
-                "src": "field_374",
-                "data-tracker": "field_1229",
-            },
+            {"src": "field_374", "data-tracker": "field_1229",},
             # Modified by
             {
                 "src": "field_505_raw",
@@ -129,40 +95,29 @@ FIELD_MAPS = {
                 "handler": handle_connection,
             },
             #  INVENTORY_TRACKING
-            {
-                "src": "field_371",
-                "data-tracker": "field_1125",
-            },
+            {"src": "field_371", "data-tracker": "field_1125",},
             #  STATUS
-            {
-                "src": "field_370",
-                "data-tracker": "field_1068",
-            },
+            {"src": "field_370", "data-tracker": "field_1068",},
             # UNIT_OF_MEASURE
-            {
-                "src": "field_377",
-                "data-tracker": "field_2420",
-            },
+            {"src": "field_377", "data-tracker": "field_2420",},
             # Object code
-            {
-                "src": "field_920",
-                "data-tracker": "field_3462",
-            },
+            {"src": "field_920", "data-tracker": "field_3462",},
             # Re-Order Threshold
-            {
-                "src": "field_922",
-                "data-tracker": "field_3902",
-            },
+            {"src": "field_922", "data-tracker": "field_3902",},
             # Re-order Turnaround Time
-            {
-                "src": "field_923",
-                "data-tracker": "field_3903",
-            },
+            {"src": "field_923", "data-tracker": "field_3903",},
             # Comment
-            {
-                "src": "field_924",
-                "data-tracker": "field_3905",
-            },
+            {"src": "field_924", "data-tracker": "field_3905",},
         ]
     },
+}
+
+
+SECONDARY_SIGNALS = {
+    "data-tracker": {
+        "view_197": {
+            "SECONDARY_SIGNALS": "field_1329_raw",
+            "PRIMARY_SIGNAL": "field_1121_raw",
+        }
+    }
 }

--- a/services/config/field_maps.py
+++ b/services/config/field_maps.py
@@ -118,6 +118,7 @@ SECONDARY_SIGNALS = {
         "view_197": {
             "SECONDARY_SIGNALS": "field_1329_raw",
             "PRIMARY_SIGNAL": "field_1121_raw",
+            "update_field": "field_1329",
         }
     }
 }

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -15,6 +15,7 @@ CONFIG = {
             "service_id": "e6eb94d1e7cc45c2ac452af6ae6aa534",
             "item_type": "layer",
             "layer_id": 0,
+            "object": "object_12",
             "dest_apps": {
                 "smart-mobility": {
                     "container": "view_396",

--- a/services/secondary_signals_updater.py
+++ b/services/secondary_signals_updater.py
@@ -150,9 +150,8 @@ def main(args):
     if len(payload) == 0:
         logger.info("No changes detected in Knack, doing nothing.")
         return 0
-
+    logger.info(payload)
     for record in payload:
-        logger.info(payload)
         res = knackpy.api.record(
             app_id=APP_ID,
             api_key=API_KEY,

--- a/services/secondary_signals_updater.py
+++ b/services/secondary_signals_updater.py
@@ -1,0 +1,187 @@
+"""
+Update traffic signal records with secondary signal relationships
+"""
+import argparse
+import collections
+import os
+
+import knackpy
+
+from config.field_maps import SECONDARY_SIGNALS
+from config.knack import CONFIG
+import utils
+
+APP_ID = os.getenv("KNACK_APP_ID")
+API_KEY = os.getenv("KNACK_API_KEY")
+
+def cli_args():
+    parser = argutil.get_parser(
+        "secondary_signals_updater.py",
+        "Update traffic signal records with secondary signal relationships.",
+        "app_name",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def get_new_prim_signals(signals, field_maps):
+    """
+    create a dict of primary signals and the secondary signals they control
+    data is compiled from the 'primary_signal' field on secondary signals
+    this field is maintained by ATD staff via the signals forms in the knack database
+
+    Args:
+        signals (TYPE): Description
+
+    Returns:
+        TYPE: Description
+    """
+    signals_with_children = {}
+
+    for signal in signals:
+
+        try:
+            #  get id of parent signal
+            knack_id = signal[field_maps["PRIMARY_SIGNAL"]][0]["id"]
+        except (IndexError, AttributeError):
+            #  empty key
+            continue
+
+        if knack_id not in signals_with_children:
+            #  add entry for parent signal
+            signals_with_children[knack_id] = []
+        #  add current signal to list of parent's children
+        signals_with_children[knack_id].append(signal["id"])
+
+    return signals_with_children
+
+
+def get_old_prim_signals(signals, field_maps):
+    """
+    create a dict of primary signals and the secondary signals they control
+    data is compiled from the 'secondary_signals' field on primary signals
+    this field is populated by this Python service
+
+    Args:
+        signals (TYPE): Description
+
+    Returns:
+        TYPE: Description
+    """
+    signals_with_children = {}
+
+    for signal in signals:
+        knack_id = signal["id"]
+
+        secondary_signals = []
+
+        try:
+            for secondary in signal[field_maps["SECONDARY_SIGNALS"]]:
+                secondary_signals.append(secondary["id"])
+
+                signals_with_children[knack_id] = secondary_signals
+
+        except (KeyError, AttributeError):
+            continue
+
+    return signals_with_children
+
+
+def main(args):
+    # Parse Arguments
+    app_name = args.app_name
+    container = args.container
+    logger.info(args)
+
+    # Selecting correct config for the view
+    config = CONFIG[app_name][container]
+    field_mapping = SECONDARY_SIGNALS[app_name][container]
+
+    # Get Signals Knack Data
+    kwargs = {"scene": config["scene"], "view": container}
+    data = knackpy.api.get(
+        app_id=APP_ID, api_key=API_KEY, **kwargs
+    )
+
+    primary_signals_old = get_old_prim_signals(data, field_mapping)
+    primary_signals_new = get_new_prim_signals(data, field_mapping)
+
+    """
+    Checking for three separate cases where we need to update Knack
+    1. A new secondary signal was added to a primary signal
+    2. Secondary signal(s) was/were changed that are attached a primary signal
+    3. A secondary signal was removed from a primary signal 
+    """
+
+    payload = []
+
+    for signal_id in primary_signals_new:
+        """
+        identify new and changed primary-secondary relationships
+        """
+        if signal_id in primary_signals_old:
+            new_secondaries = collections.Counter(primary_signals_new[signal_id])
+            old_secondaries = collections.Counter(primary_signals_old[signal_id])
+
+            # Checking if things have changed
+            if old_secondaries != new_secondaries:
+                payload.append(
+                    {
+                        "id": signal_id,
+                        field_mapping["update_field"]: primary_signals_new[signal_id],
+                    }
+                )
+
+        # Catching new primary-secondary relationship
+        else:
+            payload.append(
+                {"id": signal_id, field_mapping["update_field"]: primary_signals_new[signal_id]}
+            )
+
+    for signal_id in primary_signals_old:
+        """
+        identify primary-secondary relationships that have been removed
+        """
+        if signal_id not in primary_signals_new:
+            payload.append({"id": signal_id, field_mapping["update_field"]: []})
+
+    if len(payload) == 0:
+        return 0
+
+    for record in payload:
+        res = knackpy.api.record(
+            app_id=APP_ID,
+            api_key=API_KEY,
+            obj=config["object"],
+            method="update",
+            data=record,
+        )
+
+    return len(payload)
+
+
+if __name__ == "__main__":
+    # CLI arguments definition
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-a",
+        "--app-name",
+        type=str,
+        help="str: Name of the Knack App in knack.py config file",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--container",
+        type=str,
+        help="str: AKA API view that was created for downloading the location data",
+    )
+
+    args = parser.parse_args()
+
+    logger = utils.logging.getLogger(__file__)
+
+    main(args)


### PR DESCRIPTION
Migrating this [atd-data-publishing script](https://github.com/cityofaustin/atd-data-publishing/blob/production/transportation-data-publishing/data_tracker/secondary_signals_updater.py) to atd-knack-services. 

AMD maintains the `PRIMARY_SIGNAL` relationship in Knack and this script will propagate those relationships to the respective `SECONDARY_SIGNALS`. 

I didn't change much in the original script, except for using the Knack API instead of the older knackpy objects.

I did play with this in a test version of the data tracker but not exactly sure how to go about testing this.