### PR TITLE
Socrata Dataset Backup in S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ATD Knack Services is a set of python modules which automate the flow of data fr
 - [Configuration](#configuration)
 - [Services](<#services-(`/services`)>)
   - [Publish to Open Data Portal](#publish-records-to-the-open-data-portal)
+  - [Backup an Open Data Portal Dataset](#backup-an-open-data-portal-dataset)
   - [Publish to ArcGIS Online](#publish-records-to-arcgis-online)
   - [Publish to another Knack app](#publish-records-to-another-knack-app)
   - [Knack Maintenance: 311 SR Auto Asset Assign](#knack-maintenance-311-sr-auto-asset-assign)
@@ -116,6 +117,9 @@ The supported environmental variables for using these scripts are listed below. 
 - `SOCRATA_APP_TOKEN`: The Socrata app token
 - `PGREST_JWT`: A JSON web token used to authenticate PostgREST requests
 - `PGREST_ENDPOINT`: The URL of the PostgREST server. Currently available at `https://atd-knack-services.austinmobility.io`
+- `BUCKET`: Only needed for `backup_socrata.py`, S3 bucket name for storing socrata dataset backups
+- `AWS_ACCESS_ID`: Only needed for `backup_socrata.py`, AWS access credentials with read/write/delete privileges for the S3 bucket
+- `AWS_SECRET_ACCESS_KEY`: Only needed for `backup_socrata.py`, AWS access credentials with read/write/delete privileges for the S3 bucket
 
 If you'd like to run locally in Docker, create an [environment file](https://docs.docker.com/compose/env-file/) and pass it to `docker run`. For development purpsoses, this command also overwrites the contents of the container's `/app` directory with your local copy of the repo:
 
@@ -218,6 +222,31 @@ $ python records_to_socrata.py \
     -a data-tracker \
     -c view_1 \
     -d "2020-09-08T09:21:08-05:00"
+```
+
+#### CLI arguments
+
+- `--app-name, -a` (`str`, required): the name of the source Knack application
+- `--container, -c` (`str`, required): the object or view key of the source container
+- `--date, -d` (`str`, optional): an ISO-8601-compliant date string. If no timezone is provided, GMT is assumed. Only records which were modified at or after this date will be processed. If excluded, all records will be processed and the destination dataset will be
+  _completely replaced_.
+
+### Backup an Open Data Portal Dataset
+
+#### Configuration
+
+An AWS S3 bucket must be created along with the AWS access credentials and supplied in the environment variables for this script.
+Required Environment variables:
+- `BUCKET`
+- `AWS_ACCESS_ID`
+- `AWS_SECRET_ACCESS_KEY`
+
+The supplied `container`'s `socrata_resource_id` becomes a subdirectory in the s3 bucket where up to 30 days of full copies of the dataset are stored as CSVs (assuming this was run daily).
+
+```shell
+$ python backup_socrata.py \
+    -a data-tracker \
+    -c view_1
 ```
 
 #### CLI arguments

--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ $ python backup_socrata.py \
 
 - `--app-name, -a` (`str`, required): the name of the source Knack application
 - `--container, -c` (`str`, required): the object or view key of the source container
-- `--date, -d` (`str`, optional): an ISO-8601-compliant date string. If no timezone is provided, GMT is assumed. Only records which were modified at or after this date will be processed. If excluded, all records will be processed and the destination dataset will be
-  _completely replaced_.
 
 ### Publish records to ArcGIS Online
 

--- a/requirements_development.txt
+++ b/requirements_development.txt
@@ -1,6 +1,7 @@
 arrow==0.15.*
 knackpy==1.0.*
 sodapy==2.1.*
+boto3==1.19.*
 # -- packages for test suite --
 black
 flake8==3.*

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -2,3 +2,4 @@ arcgis==1.8.*
 arrow==0.15.*
 knackpy==1.0.*
 sodapy==2.1.*
+boto3==1.19.*

--- a/services/backup_socrata.py
+++ b/services/backup_socrata.py
@@ -11,10 +11,11 @@ import utils
 BUCKET = os.getenv("BUCKET")
 AWS_ACCESS_ID = os.getenv("AWS_ACCESS_ID")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+SOCRATA_APP_TOKEN = os.getenv("SOCRATA_APP_TOKEN")
 
 
 def export_dataset(resource_id):
-    url = f"https://data.austintexas.gov/resource/{resource_id}.csv?$limit=99999999"
+    url = f"https://data.austintexas.gov/resource/{resource_id}.csv?$limit=99999999?$$app_token={SOCRATA_APP_TOKEN}"
     res = requests.get(url)
     data = res.text
     return data

--- a/services/backup_socrata.py
+++ b/services/backup_socrata.py
@@ -23,7 +23,9 @@ def export_dataset(resource_id):
 
 def main(args):
     aws_s3_client = boto3.client(
-        "s3", aws_access_key_id=AWS_ACCESS_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        "s3",
+        aws_access_key_id=AWS_ACCESS_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
     )
 
     # Parse Arguments
@@ -33,7 +35,7 @@ def main(args):
     logger.info(resource_id)
 
     # File name and get s3 folder
-    subdir = resource_id.replace('-', '_')  # folder name is resource ID
+    subdir = resource_id.replace("-", "_")  # folder name is resource ID
     timestamp = datetime.datetime.now()
     file_name = timestamp.strftime("%y_%m_%d")
     file_name = f"{subdir}/{file_name}.csv"
@@ -46,12 +48,17 @@ def main(args):
     logger.info(f"created backup file: {file_name}")
 
     # Keeping only the last 30 days of data
-    s3_file_list = aws_s3_client.list_objects_v2(Bucket=BUCKET, Prefix=subdir)["Contents"]
+    s3_file_list = aws_s3_client.list_objects_v2(Bucket=BUCKET, Prefix=subdir)[
+        "Contents"
+    ]
     if len(s3_file_list) > 30:
-        get_last_modified = lambda obj: int(obj['LastModified'].strftime('%s'))
-        oldest_file = [obj['Key'] for obj in sorted(s3_file_list, key=get_last_modified)][0]
+        get_last_modified = lambda obj: int(obj["LastModified"].strftime("%s"))
+        oldest_file = [
+            obj["Key"] for obj in sorted(s3_file_list, key=get_last_modified)
+        ][0]
         aws_s3_client.delete_object(Bucket=BUCKET, Key=oldest_file)
         logger.info(f"deleted backup file: {oldest_file}")
+
 
 if __name__ == "__main__":
     # CLI arguments definition

--- a/services/backup_socrata.py
+++ b/services/backup_socrata.py
@@ -15,8 +15,10 @@ SOCRATA_APP_TOKEN = os.getenv("SOCRATA_APP_TOKEN")
 
 
 def export_dataset(resource_id):
-    url = f"https://data.austintexas.gov/resource/{resource_id}.csv?$limit=99999999?$$app_token={SOCRATA_APP_TOKEN}"
+    url = f"https://data.austintexas.gov/resource/{resource_id}.csv?$limit=99999999&$$app_token={SOCRATA_APP_TOKEN}"
     res = requests.get(url)
+    if res.status_code != 200:
+        raise res.text
     data = res.text
     return data
 

--- a/services/backup_socrata.py
+++ b/services/backup_socrata.py
@@ -1,0 +1,77 @@
+import argparse
+import datetime
+import os
+import requests
+
+import boto3
+
+from config.knack import CONFIG
+import utils
+
+BUCKET = os.getenv("BUCKET")
+AWS_ACCESS_ID = os.getenv("AWS_ACCESS_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+
+
+def export_dataset(resource_id):
+    url = f"https://data.austintexas.gov/resource/{resource_id}.csv?$limit=99999999"
+    res = requests.get(url)
+    data = res.text
+    return data
+
+
+def main(args):
+    aws_s3_client = boto3.client(
+        "s3", aws_access_key_id=AWS_ACCESS_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+    )
+
+    # Parse Arguments
+    app_name = args.app_name
+    container = args.container
+    resource_id = CONFIG[app_name][container]["socrata_resource_id"]
+    logger.info(resource_id)
+
+    # File name and get s3 folder
+    subdir = resource_id.replace('-', '_')  # folder name is resource ID
+    timestamp = datetime.datetime.now()
+    file_name = timestamp.strftime("%y_%m_%d")
+    file_name = f"{subdir}/{file_name}.csv"
+
+    # Get data from Socrata
+    body = export_dataset(resource_id)
+
+    # Upload CSV to s3
+    aws_s3_client.put_object(Body=body, Bucket=BUCKET, Key=file_name)
+    logger.info(f"created backup file: {file_name}")
+
+    # Keeping only the last 30 days of data
+    s3_file_list = aws_s3_client.list_objects_v2(Bucket=BUCKET, Prefix=subdir)["Contents"]
+    if len(s3_file_list) > 30:
+        get_last_modified = lambda obj: int(obj['LastModified'].strftime('%s'))
+        oldest_file = [obj['Key'] for obj in sorted(s3_file_list, key=get_last_modified)][0]
+        aws_s3_client.delete_object(Bucket=BUCKET, Key=oldest_file)
+        logger.info(f"deleted backup file: {oldest_file}")
+
+if __name__ == "__main__":
+    # CLI arguments definition
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-a",
+        "--app-name",
+        type=str,
+        help="str: Name of the Knack App in knack.py config file",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--container",
+        type=str,
+        help="str: AKA API view in the config.py file with the selected socrata_resource_id to backup.",
+    )
+
+    args = parser.parse_args()
+
+    logger = utils.logging.getLogger(__file__)
+
+    main(args)


### PR DESCRIPTION
Service that downloads the a view's `socrata_resource_id`, and stores it in S3 and is configured to have a maximum of 30 backup files per dataset.

There is a need for backups on a dataset like [AMD inventory](https://datahub.austintexas.gov/Transportation-and-Mobility/Arterial-Management-Materials-Warehouse-Inventory/hcaw-evi2) where it is just a snapshot in time of the Knack data. Socrata becomes the sole place where this is stored so it would be good to have a backup incase it is accidentally overwritten. 