### PR TITLE
Add config for internal school beacons dataset

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -175,11 +175,6 @@ CONFIG = {
             "service_id": "ebde70df086942c286dcf9f3f3449f2f",
             "layer_id": 0,
             "item_type": "layer",
-        },
-        "view_3898": {
-            "description": "School Beacons EDP",
-            "scene": "scene_1556",
-            "modified_date_field": "field_4038",
             "socrata_resource_id": "8whb-sg4d"
         },
         "view_3488": {

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -176,6 +176,12 @@ CONFIG = {
             "layer_id": 0,
             "item_type": "layer",
         },
+        "view_3898": {
+            "description": "School Beacons EDP",
+            "scene": "scene_1556",
+            "modified_date_field": "field_4038",
+            "socrata_resource_id": "8whb-sg4d"
+        },
         "view_3488": {
             "description": "Signal studies for signal evaluations map",
             "scene": "scene_1233",

--- a/services/records_to_knack.py
+++ b/services/records_to_knack.py
@@ -15,7 +15,7 @@ def format_filter_date(date_from_args):
 
 
 def get_pks(field_map, app_name_dest):
-    """ return the src and destination field name of the primay key """
+    """ return the src and destination field name of the primary key """
     pk_field = [f for f in field_map if f.get("primary_key")]
     try:
         assert len(pk_field) == 1


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/13946

https://datahub.austintexas.gov/Transportation-and-Mobility/School-Zone-Beacons-Internal/8whb-sg4d
it is an internal dataset, so you will need to login to see it


corresponding airflow PR: https://github.com/cityofaustin/atd-airflow/pull/181

I changed a column in the knack view to use the text version (ATD_location_id) of the column also named `location` that had this: `LOC23-022820` since it was throwing errors in socrata to have two different columns named location, where one was text and not a location type. 


<br class="Apple-interchange-newline">