### PR TITLE
Reduce AGOL Chunk Size

### DIFF
--- a/services/records_to_agol.py
+++ b/services/records_to_agol.py
@@ -167,7 +167,7 @@ def main():
 
     logger.info("Uploading features...")
 
-    for features_chunk in chunks(features, 500):
+    for features_chunk in chunks(features, 50):
         logger.info("Uploading chunk...")
         res = resilient_layer_request(
             layer.edit_features, {"adds": features_chunk, "rollback_on_failure": False}


### PR DESCRIPTION
After my testing, it looks like 50 is the largest size that we can send to the AGOL API now. Not exactly sure why this changed but all of these records_to_agol ETLs have been failing for the past week or so. 🤷‍♂️🤷‍♂️🤷‍♂️ 