### PR TITLE
Socrata Backups: Allow for non-knack datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,19 @@ $ python backup_socrata.py \
     -c view_1
 ```
 
+Alternatively, you can supply the "four-by-four" Socrata resource ID with the `--dataset` param:
+```shell
+$ python backup_socrata.py \
+    --dataset dx9v-zd7x
+```
+
 #### CLI arguments
 
-- `--app-name, -a` (`str`, required): the name of the source Knack application
-- `--container, -c` (`str`, required): the object or view key of the source container
+- `--app-name, -a` (`str`, required<sup>*</sup>): the name of the source Knack application
+- `--container, -c` (`str`, required<sup>*</sup>): the object or view key of the source container
+- `--dataset, -f` (`str`, required<sup>*</sup>): Alternatively to app name/container, the Socrata resource ID (AKA 4x4).
+
+<sup>*</sup>either the app-name and container can be supplied or the dataset resource ID.
 
 ### Publish records to ArcGIS Online
 

--- a/services/backup_socrata.py
+++ b/services/backup_socrata.py
@@ -60,9 +60,14 @@ def main(args):
     )
 
     # Parse Arguments
-    app_name = args.app_name
-    container = args.container
-    resource_id = CONFIG[app_name][container]["socrata_resource_id"]
+    if args.app_name and args.container:
+        app_name = args.app_name
+        container = args.container
+        resource_id = CONFIG[app_name][container]["socrata_resource_id"]
+    elif args.dataset:
+        resource_id = args.dataset
+    else:
+        raise Exception("No Socrata resource argument supplied.")
     logger.info(resource_id)
 
     # File name and get s3 folder
@@ -107,6 +112,13 @@ if __name__ == "__main__":
         "--container",
         type=str,
         help="str: AKA API view in the config.py file with the selected socrata_resource_id to backup.",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--dataset",
+        type=str,
+        help="str: Alternatively to app name/container, the Socrata resource ID (AKA 4x4).",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Adding an argument to allow us to backup any Socrata dataset without having to use the Knack.py configuration for non-knack datasets.

example:
`python backup_socrata.py --dataset dx9v-zd7x` would backup our [traffic incidents dataset](https://data.austintexas.gov/Transportation-and-Mobility/Real-Time-Traffic-Incident-Reports/dx9v-zd7x/data) which doesn't have any atd-knack-services config defined (because it's not from Knack).  