### PR TITLE
There was not a typo, replace what was there

### DIFF
--- a/services/knack_location_updater.py
+++ b/services/knack_location_updater.py
@@ -233,7 +233,7 @@ def local_timestamp():
     Used to set datetimes when writing Knack records, because Knack assumes input
     time values are in local time.
     """
-    return arrow.now("US/Central").replace(tzinfo="UTC").timestamp() * 1000
+    return arrow.now("US/Central").replace(tzinfo="UTC").timestamp * 1000
 
 
 def main(args):


### PR DESCRIPTION
I blame my own handling of my local environment