### PR TITLE
Upgrade to arrow v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.11-slim
 
 # Copy our own application
 WORKDIR /app

--- a/requirements_development.txt
+++ b/requirements_development.txt
@@ -1,4 +1,4 @@
-arrow==0.15.*
+arrow==1.*
 knackpy==1.0.*
 sodapy==2.1.*
 boto3==1.19.*

--- a/requirements_development.txt
+++ b/requirements_development.txt
@@ -1,3 +1,4 @@
+arcgis==1.*
 arrow==1.*
 knackpy==1.0.*
 sodapy==2.1.*

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,5 +1,5 @@
 arcgis==1.8.*
-arrow==0.15.*
+arrow==1.*
 knackpy==1.0.*
 sodapy==2.1.*
 boto3==1.19.*

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,4 +1,4 @@
-arcgis==1.8.*
+arcgis==1.*
 arrow==1.*
 knackpy==1.0.*
 sodapy==2.1.*

--- a/services/knack_location_updater.py
+++ b/services/knack_location_updater.py
@@ -2,7 +2,6 @@
 """ Fetch Knack records from Postgres(t) and update the location information """
 
 import argparse
-import logging
 import os
 import requests
 
@@ -227,15 +226,6 @@ def handle_features(changed, layer, record, res):
     return record, changed
 
 
-def local_timestamp():
-    """
-    Create a "local" timestamp (in milliseconds), ie local time represented as a unix timestamp.
-    Used to set datetimes when writing Knack records, because Knack assumes input
-    time values are in local time.
-    """
-    return arrow.now("US/Central").replace(tzinfo="UTC").timestamp() * 1000
-
-
 def main(args):
     # Parse Arguments
     app_name = args.app_name
@@ -296,7 +286,7 @@ def main(args):
             record = {key: record[key] for key in output_keys}
             # Two additional fields for every record:
             record[update_processed_field] = True
-            record[modified_date_field] = local_timestamp()
+            record[modified_date_field] = utils.knack.local_timestamp()
             try:
                 knackpy.api.record(
                     app_id=APP_ID,

--- a/services/knack_street_seg_updater.py
+++ b/services/knack_street_seg_updater.py
@@ -2,9 +2,7 @@
 import argparse
 import os
 import requests
-import time
 
-import arrow
 import knackpy
 
 import utils
@@ -70,14 +68,6 @@ def are_equal(knack_dict, agol_dict):
         logger.info(f"mismatched field(s): {mismatched_keys}")
         return False
     return True
-
-def local_timestamp():
-    """
-    Create a "local" timestamp (in milliseconds), ie local time represented as a unix timestamp.
-    Used to set datetimes when writing Knack records, because Knack assumes input
-    time values are in local time.
-    """
-    return arrow.now("US/Central").replace(tzinfo="UTC").timestamp * 1000
 
 def create_knack_field_mapping(record):
     """
@@ -168,7 +158,7 @@ def main(args):
                 if not are_equal(street_segment, segment_data):
                     logger.info(f'Change detected for segment ID: {street_segment[config["primary_key"]]}')
                     segment_data["id"] = street_segment["id"]
-                    segment_data[config["modified_date_col_name"]] = local_timestamp()
+                    segment_data[config["modified_date_col_name"]] = utils.knack.local_timestamp()
                     # Uploading updated data back to Knack
                     update_record(config, segment_data, field_mapping)
             else:

--- a/services/sr_asset_assign.py
+++ b/services/sr_asset_assign.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 """ Fetch 3-1-1 SR records from Knack and assign a nearby asset """
-
 import argparse
-import logging
 import os
 import requests
 
-import arrow
 from config.knack import CONFIG
 from config.locations import ASSET_CONFIG
 import utils
@@ -126,15 +123,6 @@ def get_params(layer_config, point, token):
     return params
 
 
-def local_timestamp():
-    """
-    Create a "local" timestamp (in milliseconds), ie local time represented as a unix timestamp.
-    Used to set datetimes when writing Knack records, because Knack assumes input
-    time values are in local time.
-    """
-    return arrow.now("US/Central").replace(tzinfo="UTC").timestamp * 1000
-
-
 def submit_knack_form(token, record):
     """
     Submit data via Knack form view.
@@ -215,7 +203,7 @@ def main(args):
             # Updating a record in Knack
             record = {key: record[key] for key in output_keys}
             # Add modified date field for every record:
-            record[modified_date_field] = local_timestamp()
+            record[modified_date_field] = utils.knack.local_timestamp()
             try:
                 submit_knack_form(token_knack, record)
             except Exception as e:

--- a/services/utils/knack.py
+++ b/services/utils/knack.py
@@ -1,4 +1,5 @@
 import arrow
+from dateutil import tz
 
 
 def socrata_formatter_location(value):
@@ -30,6 +31,15 @@ def socrata_formatter_multipoint(value):
         }
     except ValueError:
         return None
+
+
+def local_timestamp(tzname="US/Central"):
+    """
+    Create a "local" timestamp (in milliseconds), ie local time represented as a unix timestamp.
+    Used to set datetimes when writing Knack records, because Knack assumes input
+    time values are in local time.
+    """
+    return arrow.now(tzname).replace(tzinfo=tz.gettz("UTC")).int_timestamp * 1000
 
 
 def date_filter_on_or_after(timestamp, date_field, tzinfo="US/Central", use_time=False):


### PR DESCRIPTION
The `arrow` package has been at v1 for a while now. We should upgrade. Here's the [migration guide](https://github.com/arrow-py/arrow/issues/832).



I can't test this because I can't build the Docker image locally 🤯 