### PR TITLE
Purchase request copier service

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -351,6 +351,20 @@ CONFIG = {
         },
     },
     "finance-purchasing": {
+        "view_211": {
+            "description": "Purchase Requests",
+            "scene": "scene_84",
+            "object": "object_1",
+            "requester_field_id": "field_12",
+            "copied_by_field_id": "field_283",
+            "copy_field_id": "field_268",
+            "unique_id_field_id": "field_11",
+            "pr_items": {
+                    "object": "object_4",
+                    "pr_field_id": "field_269",
+                    "pr_connection_field_id": "field_20",
+                },
+        },
         "view_788": {
             "description": "Inventory items",
             "scene": "scene_84",

--- a/services/purchase_request_copier.py
+++ b/services/purchase_request_copier.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+import argparse
+import os
+
+import knackpy
+
+from config.knack import CONFIG
+import utils
+
+APP_ID = os.getenv("KNACK_APP_ID")
+API_KEY = os.getenv("KNACK_API_KEY")
+
+
+def handle_record_types(knack_record):
+    """
+    Reformat the connection field types and ignore the automatically generated fields
+    """
+    output_record = {}
+    for field_name in knack_record.fields:
+        field_data = knack_record.fields[field_name]
+        # get list of record IDs for connection fields
+        if field_data.field_def.type == "connection":
+            if knack_record.get(field_name):
+                output_record[field_name] = [
+                    item["id"] for item in knack_record.get(field_name)
+                ]
+            else:
+                output_record[field_name] = None
+        # ignoring auto-generated fields
+        elif field_data.field_def.type in [
+            "equation",
+            "concatenation",
+            "auto_increment",
+        ]:
+            continue
+        # All other record types
+        else:
+            output_record[field_name] = knack_record.get(field_name)
+
+    return output_record
+
+
+def assign_requester(data, requester_field_id, copied_by_field_id):
+    """
+    Makes the requester the person who created the copied record.
+    """
+    copied_by = data.pop(copied_by_field_id)
+    data[requester_field_id] = copied_by
+    return data
+
+
+def main(args):
+    # Process arguments
+    app_name = args.app_name
+    container = args.container
+    logger.info(args)
+    config = CONFIG[app_name][container]
+
+    # Use a "free" API call to check for if there's purchase requests to be copied
+    app = knackpy.App(app_id=APP_ID, api_key=None)
+    records = app.get(container, filters=None)
+
+    if len(records) == 0:
+        logger.info("No purchase requests to copy, did nothing.")
+        return 0
+
+    logger.info(f"Copying {len(records)} Purchase Requests")
+    # Creating a copy of the purchase request and assigning it to person requesting the copy
+    for purchase_request in records:
+        unique_id = purchase_request.get(config["unique_id_field_id"])
+        logger.info(f"Copying Purchase Request with ID: {unique_id}")
+        data = handle_record_types(purchase_request)
+        data = assign_requester(
+            data, config["requester_field_id"], config["copied_by_field_id"]
+        )
+
+        # set copy PR to "No"
+        data[config["copy_field_id"]] = False
+
+        # Create new record that was copied
+        copied_record = knackpy.api.record(
+            app_id=APP_ID,
+            api_key=API_KEY,
+            obj=config["object"],
+            method="create",
+            data=data,
+        )
+        logger.info(
+            f"New Purchase Request record generated with ID: {copied_record.get(config['unique_id_field_id'])}"
+        )
+
+        # Update the original copy to remove it from our queue of requested copies
+        old_record = {"id": purchase_request.get("id"), config["copy_field_id"]: False}
+        original_record = knackpy.api.record(
+            app_id=APP_ID,
+            api_key=API_KEY,
+            obj=config["object"],
+            method="update",
+            data=old_record,
+        )
+
+        # Get the Auto increment field ID, so we can search the PR items table
+        item_filter = {
+            "match": "and",
+            "rules": [
+                {
+                    "field": config["pr_items"]["pr_field_id"],
+                    "operator": "is",
+                    "value": unique_id,
+                }
+            ],
+        }
+        app = knackpy.App(app_id=APP_ID, api_key=API_KEY)
+        item_records = app.get(config["pr_items"]["object"], filters=item_filter)
+
+        logger.info(f"Copying {len(item_records)} Purchase Request items")
+        # Copying over PR items to the newly created PR
+        for item in item_records:
+            item_data = handle_record_types(item)
+
+            # set item connection to copied purchase request record
+            item_data[config["pr_items"]["pr_connection_field_id"]] = [
+                copied_record["id"]
+            ]
+            # set item unique ID to purchase request unique ID
+            item_data[config["pr_items"]["pr_field_id"]] = copied_record.get(
+                config["unique_id_field_id"]
+            )
+            item_data.pop("id")
+
+            # generates new PR item as a child record to the copied PR
+            new_item = knackpy.api.record(
+                app_id=APP_ID,
+                api_key=API_KEY,
+                obj=config["pr_items"]["object"],
+                method="create",
+                data=item_data,
+            )
+    return len(records)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-a",
+        "--app-name",
+        type=str,
+        help="str: Name of the Knack App in knack.py config file",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--container",
+        type=str,
+        help="str: AKA API view that was created for downloading the location data",
+    )
+
+    args = parser.parse_args()
+
+    logger = utils.logging.getLogger(__file__)
+
+    main(args)

--- a/services/purchase_request_copier.py
+++ b/services/purchase_request_copier.py
@@ -57,12 +57,15 @@ def main(args):
     config = CONFIG[app_name][container]
 
     # Use a "free" API call to check for if there's purchase requests to be copied
-    app = knackpy.App(app_id=APP_ID, api_key=None)
-    records = app.get(container, filters=None)
+    records = knackpy.api.get(app_id=APP_ID, view=container, scene=config["scene"])
 
     if len(records) == 0:
         logger.info("No purchase requests to copy, did nothing.")
         return 0
+
+    # If we have records to copy, get the full metadata of the app/records.
+    app = knackpy.App(app_id=APP_ID, api_key=API_KEY)
+    records = app.get(container, filters=None)
 
     logger.info(f"Copying {len(records)} Purchase Requests")
     # Creating a copy of the purchase request and assigning it to person requesting the copy
@@ -110,7 +113,6 @@ def main(args):
                 }
             ],
         }
-        app = knackpy.App(app_id=APP_ID, api_key=API_KEY)
         item_records = app.get(config["pr_items"]["object"], filters=item_filter)
 
         logger.info(f"Copying {len(item_records)} Purchase Request items")


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/16060

Migrating a [data-publishing script](https://github.com/cityofaustin/atd-data-publishing/blob/production/transportation-data-publishing/finance_admin/pr_copier.py) that creates copies of purchase request records. Users flag these records in Knack, meanwhile the ETL checks a queue of flagged records. If it finds any, it will create copies and assign the user who copied them as the requester. Also creates copies of the purchase request items which are child records of the main purchase request.

Not super sure how to go about testing but what I've been doing:
1. Login to knack builder to the [test Knack app](https://builder.knack.com/atd/test-feb-29-2024-finance-and-purchasing-system--production/records/objects/object_1)
2. Pick a random purchase request in the records view and set the `COPY_PR` value to True and set the `COPIED_BY` to a user
<img width="497" alt="Screenshot 2024-03-01 at 2 26 58 PM" src="https://github.com/cityofaustin/atd-knack-services/assets/30810522/76e354da-fdc2-410e-8561-11548921499e">

3. You can verify the PR is ready to be copied if it appears on this API view table: https://atd.knack.com/test-feb-29-2024-finance-and-purchasing-system--production#api-views/
<img width="610" alt="Screenshot 2024-03-01 at 2 28 30 PM" src="https://github.com/cityofaustin/atd-knack-services/assets/30810522/78cbd86b-8eef-45ee-a7c6-bc446ba01efd">

4. Get your environment variables set up secrets are in the "Knack Finance and Purchasing" 1pass item make sure you use TEST secrets
5. Run the script with arguments `python services/purchase_request_copier.py -a finance-purchasing -c view_211`
6. Check the logs and make sure it copied the correct PR and child PR items, example:

```
purchase_request_copier.py.INFO: Copying 1 Purchase Requests
purchase_request_copier.py.INFO: Copying Purchase Request with ID: 7525
purchase_request_copier.py.INFO: New Purchase Request record generated with ID: 7618
purchase_request_copier.py.INFO: Copying 5 Purchase Request items
```

I'm not sure what other things we may need to test for but if it copies the PR and assigns the correct user along with the PR items, I think we're good to 🚢 .

- [ ]  Reminder when we deploy this to production to add the field `AUTO_INCREMENT` to the purchase request API view in Knack. This was the only change I found we needed on the Knack end of things to get this to work.