### PR TITLE
Rework Dockerfile for build compatibility on ARM, Intel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
-FROM python:3.8-slim
-
-# Copy our own application
-WORKDIR /app
+FROM python:3.12-slim-bookworm
+RUN apt-get update && apt-get install -y build-essential
 COPY . /app/atd-knack-services
-
-RUN chmod -R 755 /app/*
-
-# # Proceed to install the requirements...do
-RUN cd /app/atd-knack-services && apt-get update && \
-    pip install -r requirements_production.txt
+WORKDIR /app/atd-knack-services
+RUN pip install -r requirements_production.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim-bookworm
 RUN apt-get update && apt-get install -y build-essential
 COPY . /app/atd-knack-services
-WORKDIR /app/atd-knack-services
+WORKDIR /app
 RUN find /app -type f -name "*.py" -exec chmod +x {} \;
-RUN pip install -r requirements_production.txt
+RUN pip install -r /app/atd-knack-services/requirements_production.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM python:3.12-slim-bookworm
 RUN apt-get update && apt-get install -y build-essential
 COPY . /app/atd-knack-services
 WORKDIR /app/atd-knack-services
+RUN find /app -type f -name "*.py" -exec chmod +x {} \;
 RUN pip install -r requirements_production.txt


### PR DESCRIPTION
This PR intends to address https://github.com/cityofaustin/atd-data-tech/issues/16553.

It reworks the Dockerfile to:

* Build natively on Intel, ARM
* Build under `buildx` for the same platforms
* Use an updated version of python
* Remove unneeded build steps

### Consideration

I have only tested that the image builds, and I have not tested that anything in the repo runs on it. I'll be realllly surprised if there's any snag, but I did want to say that. FWIW, both `python` and `python3` are in the path, so it should be a drop in replacement.

### Testing

Not sure exactly, but if it works for what you're working on, that feels pretty promising. 🙏 

### Correction

 I said in slack that `slim` was a debian release, and that was wrong. Here, we're using `FROM python:3.12-slim-bookworm` now, where slim designates a minimal docker image and bookworm designates the current stable debian release.