### PR TITLE
Use python 3.11 instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.11-slim-bookworm
 RUN apt-get update && apt-get install -y build-essential
 COPY . /app/atd-knack-services
 WORKDIR /app


### PR DESCRIPTION
We have been getting boto errors on airflow, reproducible here:

```
>>> import boto3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.12/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/usr/local/lib/python3.12/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/usr/local/lib/python3.12/site-packages/botocore/session.py", line 28, in <module>
    import botocore.configloader
  File "/usr/local/lib/python3.12/site-packages/botocore/configloader.py", line 19, in <module>
    from botocore.compat import six
  File "/usr/local/lib/python3.12/site-packages/botocore/compat.py", line 34, in <module>
    from botocore.vendored.six.moves import http_client
ModuleNotFoundError: No module named 'botocore.vendored.six.moves'
```