### PR TITLE
Config Traffic Detectors Weekly Snapshot

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -107,7 +107,7 @@ CONFIG = {
             "item_type": "layer",
         },
         "view_1333": {
-            "description": "Detectors",
+            "description": "Traffic Detectors",
             "scene": "scene_468",
             "modified_date_field": "field_1533",
             "socrata_resource_id": "qpuw-8eeb",
@@ -115,6 +115,15 @@ CONFIG = {
             "service_id": "47d17ff3ce664849a16b9974979cd12e",
             "layer_id": 0,
             "item_type": "layer",
+        },
+        "view_4274": {
+            "description": "Traffic Detectors Weekly Snapshot",
+            "scene": "scene_468",
+            "modified_date_field": "field_1533",
+            "socrata_resource_id": "g939-dyvz",
+            "location_field_id": "field_182",
+            "append_timestamps_socrata": {"key": "published_date"},
+            "no_replace_socrata": True,
         },
         "view_540": {
             "description": "Travel Sensors",


### PR DESCRIPTION
Part of: https://github.com/cityofaustin/atd-data-tech/issues/19844

Airflow PR coming soon if you would rather test there.

Adds some config for a new socrata [dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Traffic-Detectors-Weekly-Archive/g939-dyvz/about_data) which will contain a running log of traffic detectors. Each week the current snapshot of detectors will be appended to this dataset along with the `published_date`.

If you wish to test:
```
python services/records_to_postgrest.py -a data-tracker -c view_4274 -d 1970-01-01
```

followed by:
```
python services/records_to_socrata.py -a data-tracker -c view_4274 -d 1970-01-01
```

You should now see some additional rows added to the [dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Traffic-Detectors-Weekly-Archive/g939-dyvz/about_data) with a fresh`published_date`.


The 1970's date parameter is necessary as without it, records_to_socrata will attempt to replace the dataset completely. Instead, it will insert new records. The `no_replace_socrata` config should protect you from doing this:
> Replacement of this Socrata dataset is not allowed. Specify a date range or
            modify the 'no_replace_socrata' setting in this container's config.

The airflow PR will also have a 30-day socrata backup incase we truncate this dataset accidentally 😇 