### PR TITLE
Additional logging for records_to_agol

### DIFF
--- a/services/records_to_agol.py
+++ b/services/records_to_agol.py
@@ -129,7 +129,7 @@ def main():
         """
         Completely replace destination data. arcgis does have layer.manager.truncate()
         method, but this method is not supported on the parent layer of parent-child
-        relationships. So we truncate the layer by deleteing with a "where 1=1"
+        relationships. So we truncate the layer by deleting with a "where 1=1"
         expression. We use the "future" option to avoid request timeouts on large
         datasets.
         """
@@ -140,6 +140,7 @@ def main():
         # returns a "<Future>" response class which does not appear to be documented
         while res._state != "FINISHED":
             logger.info(f"Response state: {res._state}. Sleeping for 1 second")
+            logger.info(res._state)
             time.sleep(1)
         utils.agol.handle_response(res._result)
 


### PR DESCRIPTION
Just adding one additional item for logging the state of our request. We get random timeouts from this script all the time, and we've never been able to figure out why. I have a feeling it's sending some weird state that is not `FINISHED`. [Example](https://austininnovation.slack.com/archives/C013G4RNJ01/p1737386972003669). 