### PR TITLE
Update the reimbursement config to draw from one view

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -353,16 +353,9 @@ CONFIG = {
             "modified_date_field": "field_2559",
             "socrata_resource_id": "qvth-gwdv",
         },
-        # Similarly views 3526 and 3527 push to the same socrata dataset (see note above)
-        "view_3526": {
-            "description": "Signs reimbursement tracking",
-            "scene": "scene_1249",
-            "modified_date_field": "field_4000",
-            "socrata_resource_id": "pma8-yy5k",
-        },
         "view_3527": {
-            "description": "Markings reimbursement tracking",
-            "scene": "scene_1249",
+            "description": "Signs and Markings reimbursement tracking",
+            "scene": "scene_1612",
             "modified_date_field": "field_4000",
             "socrata_resource_id": "pma8-yy5k",
         },


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/16090

Here is the socrata link: https://datahub.austintexas.gov/Transportation-and-Mobility/Street-Signs-and-Roadway-Markings-Reimbursements/pma8-yy5k/about_data

Here is the companion airflow PR: https://github.com/cityofaustin/atd-airflow/pull/281

After this is merged and knack-services docker image is updated, we can test using the airflow script. 

to run locally
set up your env file with the knack app id and api key for signs and markings, the postgrest jwt and endpoint, and the socrata key, id and token (this [PR](https://github.com/cityofaustin/atd-airflow/pull/281/files) could help with the 1pw names)

```bash
python records_to_postgrest.py -a signs-markings -c view_3527
```

```bash
python records_to_socrata.py -a signs-markings -c view_3527
```


From my testing on Friday

![Screenshot 2025-05-05 at 10 43 10 AM](https://github.com/user-attachments/assets/3b4be81c-1e90-4550-acbc-0c86283854db)


