### PR TITLE
Development Services config + special character field names

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -439,4 +439,60 @@ CONFIG = {
             "modified_date_field": "field_179",
         }
     },
+    "development-services": {
+        "view_2814": {
+            "description": "TIA mitigations",
+            "scene": "scene_787",
+            "modified_date_field": "field_491",
+            "socrata_resource_id": "mvy5-atr5",
+        },
+        "view_2926": {
+            "description": "TS cases",
+            "scene": "scene_619",
+            "modified_date_field": "field_338",
+            "socrata_resource_id": "c8zb-em9a",
+        },
+        "view_2919": {
+            "description": "TS scope cycles",
+            "scene": "scene_832",
+            "modified_date_field": "field_509",
+            "socrata_resource_id": "wvna-ucv7",
+        },
+        "view_2920": {
+            "description": "TS submission cycles",
+            "scene": "scene_833",
+            "modified_date_field": "field_229",
+            "socrata_resource_id": "v6ib-ev9u",
+        },
+        "view_2921": {
+            "description": "SIF formal assessments",
+            "scene": "scene_834",
+            "modified_date_field": "field_882",
+            "socrata_resource_id": "v59q-edrj",
+        },
+        "view_2924": {
+            "description": "SIF formal reviews",
+            "scene": "scene_837",
+            "modified_date_field": "field_1749",
+            "socrata_resource_id": "f6bi-75d4",
+        },
+        "view_2922": {
+            "description": "SWF Final assessments",
+            "scene": "scene_835",
+            "modified_date_field": "field_882",
+            "socrata_resource_id": "u7w8-4hav",
+        },
+        "view_2925": {
+            "description": "SWF Final reviews",
+            "scene": "scene_838",
+            "modified_date_field": "field_1749",
+            "socrata_resource_id": "y5pw-nh8x",
+        },
+        "view_2923": {
+            "description": "TIA determinations",
+            "scene": "scene_836",
+            "modified_date_field": "field_1374",
+            "socrata_resource_id": "289q-zknx",
+        },
+    }
 }

--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -450,7 +450,7 @@ CONFIG = {
             "description": "TS cases",
             "scene": "scene_619",
             "modified_date_field": "field_338",
-            "socrata_resource_id": "c8zb-em9a",
+            "socrata_resource_id": "sjcw-u8cb",
         },
         "view_2919": {
             "description": "TS scope cycles",

--- a/services/utils/shared.py
+++ b/services/utils/shared.py
@@ -2,11 +2,16 @@ import re
 
 
 def format_keys(record):
-    """Format Knack record keys by converting to lower case and replacing space
-    with underscores. Then, replaces all special characters with underscores."""
-    return {
-        re.sub(
-            r"[^a-z0-9_]+", "", key.lower().replace(" ", "_").replace("-", "_")
-        ): val
-        for key, val in record.items()
-    }
+    """Rebuild a Knack record by editing the keys by:
+    1. Convert to lower case
+    2. Replacing space and dashes with underscores.
+    3. Replace all special characters with underscores.
+    """
+    output = {}
+    for key, val in record.items():
+        key = key.lower()
+        key = key.replace(" ", "_")
+        key = key.replace("-", "_")
+        key = re.sub(r"[^a-z0-9_]+", "", key)
+        output[key] = val
+    return output

--- a/services/utils/shared.py
+++ b/services/utils/shared.py
@@ -1,7 +1,12 @@
+import re
+
+
 def format_keys(record):
     """Format Knack record keys by converting to lower case and replacing space
-    with underscores"""
+    with underscores. Then, replaces all special characters with underscores."""
     return {
-        key.lower().replace(" ", "_").replace("-", "_"): val
+        re.sub(
+            r"[^a-z0-9_]+", "", key.lower().replace(" ", "_").replace("-", "_")
+        ): val
         for key, val in record.items()
     }


### PR DESCRIPTION
Part of: https://github.com/cityofaustin/atd-data-tech/issues/21684

Config for setting up some new data portal [datasets](https://datahub.austintexas.gov/browse?tags=transportation+development+services&sortBy=relevance&pageSize=20).

***

One thing that came up is we had a new columns that contained special characters, which socrata does not allow in their api field names. I added some handling for those special characters.

As for the regex, I used AI to help me with that one 😅. Basically, we want to remove all special characters, and swap spaces and dashes with underscores. Obligatory regex license provided [here](https://www.regexlicensing.org/).

chatgpt:
```
Step-by-step Breakdown of the Regex r'[^a-z0-9_]+':

[...] – Character class
Square brackets match any one character inside them.

Example: [abc] matches 'a', 'b', or 'c'.

^ (inside [...]) – Negation
If ^ is at the start of a character class, it means “not any of these characters.”

So: [^a-z0-9_] means: match any character not listed.

a-z – Lowercase letters
Matches any single lowercase letter from a to z.

0-9 – Digits
Matches any digit from 0 to 9.

_ – Underscore
Explicitly includes _ as an allowed character.

[^a-z0-9_] – Match disallowed characters
This part matches any character that is not a lowercase letter, digit, or underscore.

+ – One or more
The + means: match one or more of the preceding pattern.

So if you have something like @#$%^, it will match the entire sequence in one go.

```

I'm not super sure how we want to test if this will break something, as this code is actually used in both socrata and AGOL scripts. But in theory, we shouldn't have any *socrata* field names that contain special chars anyway? We currently have 27 records_to_socrata tasks on airflow currently.