### PR TITLE
Remove records_to_agol async delete

### DIFF
--- a/services/records_to_agol.py
+++ b/services/records_to_agol.py
@@ -130,19 +130,13 @@ def main():
         Completely replace destination data. arcgis does have layer.manager.truncate()
         method, but this method is not supported on the parent layer of parent-child
         relationships. So we truncate the layer by deleting with a "where 1=1"
-        expression. We use the "future" option to avoid request timeouts on large
-        datasets.
+        expression. 
         """
         logger.info("Deleting all features...")
         res = resilient_layer_request(
-            layer.delete_features, {"where": "1=1", "future": True}
+            layer.delete_features, {"where": "1=1"}
         )
-        # returns a "<Future>" response class which does not appear to be documented
-        while res._state != "FINISHED":
-            logger.info(f"Response state: {res._state}. Sleeping for 1 second")
-            logger.info(res._state)
-            time.sleep(1)
-        utils.agol.handle_response(res._result)
+        utils.agol.handle_response(res)
 
     else:
         """


### PR DESCRIPTION
We've been getting periodic failures for the DMS to AGOL DAG for a long time. It only has to delete 20 features and it can take several minutes until our DAG times out.

I tested it this morning locally and found that removing the `"future": True` async option for the AGOL API caused it to complete immediately. I also tested with one of our largest AGOL layers, [signs marking specifications ](https://github.com/cityofaustin/atd-airflow/blob/767708e5df522811c432e6f8431a1f0a63b9ac4a/dags/atd_knack_markings_specifications.py) and the API did not have a problem deleting all 23k features immediately. 

***

## Testing:

You can feel free to test the **production** version of the DMS to AGOL script to see it fail, just note that _sometimes_ this can take a long time and other times it's immediate. I wonder if it is somehow related to when AGOL API usage is high during the workday.

You can test this just by triggering the [DAG in airflow](https://airflow.austinmobility.io/dags/atd_knack_dms/grid?search=atd_knack_dms) and seeing the stats on how long it takes to complete.

<img width="632" height="274" alt="Screenshot 2025-07-11 at 1 06 06 PM" src="https://github.com/user-attachments/assets/9fe10278-0958-4700-b4f9-6d277b363b40" />

Ok, so if you want to test **this branch**:

Build a .env file, the only entries you should need are:

```
AGOL_PASSWORD=# 1pass entry: ArcGIS Online (AGOL) Scripts Publisher #
AGOL_USERNAME=# 1pass entry: ArcGIS Online (AGOL) Scripts Publisher #
PGREST_ENDPOINT=# 1pass entry: atd-knack-services PostgREST #
PGREST_JWT=# 1pass entry: atd-knack-services PostgREST #
KNACK_APP_ID=# 1pass entry:  Knack AMD Data Tracker #
```

First, try the problematic DMS records_to_agol:
> python services/records_to_agol.py -a data-tracker -c view_1564 

Check that it completes relatively quickly (< 30 seconds).

Now, change your env file to point to the signs and markings app:
```
KNACK_APP_ID=# 1pass entry:  Knack Signs and Markings #
```

Try the large signs markings records_to_agol:
> python services/records_to_agol.py -a signs-markings -c view_3103

This should take a while to run ~5 minutes or so but the deleting records part should be relatively quick.



