### PR TITLE
Add config for data collection requests

### DIFF
--- a/services/config/knack.py
+++ b/services/config/knack.py
@@ -247,6 +247,12 @@ CONFIG = {
             "signals_container": "view_197",
             "secondary_signals_field": "field_1329",  # Knack field name of SECONDARY_SIGNALS in the signals object
             "signal_object_id": "object_12",
+        },
+        "view_4620": {
+            "description": "Traffic count and data collection requests",
+            "scene": "scene_1872",
+            "modified_date_field": "field_2812",
+            "socrata_resource_id": "7qcz-v6sa",
         }
     },
     "signs-markings": {


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/22497

Here is the dataset: https://datahub.austintexas.gov/Transportation-and-Mobility/Traffic-Count-and-Data-Collection-Requests-COA/7qcz-v6sa/about_data

Here is the airflow PR: https://github.com/cityofaustin/atd-airflow/pull/324

I pushed these updates to docker under the tag `atddocker/atd-knack-services:latest` so that this can be tested via the airflow PR. 

If you want to run locally:
`records_to_postgrest.py -a data-tracker -c view_4620`
`records_to_socrata.py -a data-tracker -c view_4620`